### PR TITLE
Init(project): GitHub CD 플로우 및 Vercel 배포 설정

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,42 @@
+name: Synchronize to forked repo
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: sync-fork-main
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync forked repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Configure git
+        run: |
+          git config user.name "jogpfls"
+          git config user.email "${{ secrets.EMAIL }}"
+
+      - name: Add fork remote
+        env:
+          PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git remote add forked-repo https://x-access-token:${PAT}@github.com/jogpfls/CLUSTAR-CLIENT.git
+
+      - name: Push changes to forked-repo
+        run: |
+          git push --force-with-lease forked-repo main
+
+      - name: Clean up
+        if: always()
+        run: |
+          git remote remove forked-repo

--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 Summary

> - #40 

GitHub CD 플로우 및 Vercel 배포 설정을 진행합니다.

## 📚 Tasks

- sync.yml 설정
- vercel.json 설정

## 🔍 Describe

**Vercel 조직 레포 배포 제한 문제**

현재 프로젝트는 GitHub Organization 레포지토리에서 관리되고 있어요.
그런데 Vercel은 조직 레포 배포를 유료 플랜에서만 지원하기 때문에, 무료 플랜에서는 직접 배포가 불가능한 제약이 있어요.

조직 레포 → Vercel 직접 연결 → X (유료 필요)
이라는 구조적인 한계가 존재해요.

이 문제를 해결하기 위해 개인 레포지토리로 포크한 뒤, 해당 포크 레포를 Vercel에 연결하여 배포하는 방식을 선택했어요.

**개인 포크 레포 + 자동 동기화 구조**

단순히 포크만 하면 이후에 원본 레포와 코드가 어긋나는 문제가 생길 수 있어요.
그래서 이를 방지하기 위해 sync.yml을 구성해서 orga 레포의 main 브랜치 변경 사항을 개인 포크 레포로 자동 동기화하도록 했어요.

**sync.yml을 사용하는 이유**

sync.yml은 다음 목적을 위해 추가했어요. orga 레포의 main 브랜치 변경 사항을 개인 fork 레포의 main 브랜치로 강제 동기화하고 이를 통해 수동으로 포크 레포를 관리하지 않아도 되고 코드 불일치로 인한 배포 오류를 방지할 수 있으며 항상 배포 대상 레포가 최신 상태를 유지할 수 있어요.

**vercel.json 설정 이유**

Vercel 환경에서 SPA(React) 프로젝트를 배포할 경우,
기본 설정만으로는 새로고침 시 404 에러가 발생하는 문제가 있어요.
```
/           → 정상
/login      → 정상
/login 새로고침 → 404 X
```
Vercel이 /을 정적 파일 경로로 인식하기 때문에 발생하는 문제예요.
하지만 실제로는 React Router가 처리해야 하는 클라이언트 사이드 라우팅 경로예요.

vercel.json 설정을 하면 어떤 경로로 접근하든 항상 index.html로 보내고 그 이후의 라우팅은 React Router가 처리하도록 만들어서 새로고침 시 404 에러 없이 정상 동작하도록 해요.


## 👀 To Reviewer
- 언넝 다 머지하고 배포해보자 !!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
