### PR TITLE
Feat(cds): alert modal 컴포넌트 구현

### DIFF
--- a/packages/cds-ui/src/components/alert-modal/alert-modal.css.ts
+++ b/packages/cds-ui/src/components/alert-modal/alert-modal.css.ts
@@ -1,6 +1,16 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 
-import { opacityHide, opacityShow, themeVars } from '../../styles';
+import { themeVars } from '../../styles';
+
+const opacityShow = keyframes({
+  '0%': { opacity: 0 },
+  '100%': { opacity: 1 },
+});
+
+const opacityHide = keyframes({
+  '0%': { opacity: 1 },
+  '100%': { opacity: 0 },
+});
 
 export const overlay = style({
   position: 'fixed',

--- a/packages/cds-ui/src/components/modal/modal.css.ts
+++ b/packages/cds-ui/src/components/modal/modal.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 import { keyframes } from '@vanilla-extract/css';
 
-import { opacityHide, opacityShow, themeVars } from '../../styles';
+import { themeVars } from '../../styles';
 
 const contentShow = keyframes({
   '0%': {
@@ -17,6 +17,16 @@ const contentShow = keyframes({
 const contentHide = keyframes({
   '0%': { opacity: 1, transform: 'translate(-50%, -50%) scale(1)' },
   '100%': { opacity: 0, transform: 'translate(-50%, -50%) scale(0.5)' },
+});
+
+const opacityShow = keyframes({
+  '0%': { opacity: 0 },
+  '100%': { opacity: 1 },
+});
+
+const opacityHide = keyframes({
+  '0%': { opacity: 0 },
+  '100%': { opacity: 1 },
 });
 
 export const overlay = style({

--- a/packages/cds-ui/src/styles/animations.css.ts
+++ b/packages/cds-ui/src/styles/animations.css.ts
@@ -15,13 +15,3 @@ export const fadeIn = keyframes({
   '0%': { opacity: 0 },
   '100%': { opacity: 1 },
 });
-
-export const opacityShow = keyframes({
-  '0%': { opacity: 0 },
-  '100%': { opacity: 1 },
-});
-
-export const opacityHide = keyframes({
-  '0%': { opacity: 1 },
-  '100%': { opacity: 0 },
-});

--- a/packages/cds-ui/src/styles/index.ts
+++ b/packages/cds-ui/src/styles/index.ts
@@ -1,7 +1,7 @@
 import './reset.css';
 import './global.css';
 
-export { fadeIn, opacityHide, opacityShow, slideInUp } from './animations.css';
+export { fadeIn, slideInUp } from './animations.css';
 export type { Sprinkles } from './sprinkles.css';
 export { sprinkles } from './sprinkles.css';
 export { themeClass, themeVars } from './theme.css';


### PR DESCRIPTION
## 📌 Summary

>  - #128

AI 프롬프트 작성 페이지 등에서 사용될 Alert Modal을 구현했습니다.


## 📚 Tasks

- 서준님이 구현한 `modal`컴포넌트에서 동일한 애니메이션을 사용하기에 `animations.css`에서 같이 사용하도록 분리했습니다.
- `isClosing` prop과 `data-state` 속성을 활용해 모달이 닫힐 때의 애니메이션이 자연스럽게 동작하도록 했습니다.

 
- ## 🔍 Describe

- `alert modal`은 확장성을 생각해 다른 곳에서도 사용될 가능성이 있다고 판단해서 `title` 과 `description`을 `props`로 받아서 사용하도록 구현했습니다.

</br>





**커밋이 더러운 이유**
`cds/ui` 내부에서 공통 스타일을 불러올 때 습관적으로 절대 경로인 `@cds/ui`를 사용했습니다. 이로 인해 로컬 환경 및 `tsconfig.json`에서 사진과 같은 오류가 발생해서 푸시가 안되는 상황이 생겼었습니다,,, 
<img width="1584" height="512" alt="image" src="https://github.com/user-attachments/assets/a14c1481-d098-41da-a3a4-8ff12a930401" />
그래서 처음에는 `tsconfig.json`에 `rootdir`옵션이 없어서 생기는 오류인줄알고 추가해서 시도하고 다시 생각해보니 자기 자신을 절대경로로 참조하려고해서 발생했던 오류였던 것이었습니다. 
그래서 다시 상대경로로 바꿔서 푸시했습니당,,, 그래서 커밋이 조금 더러워요,,,,




<details>
<summary> 사용법 </summary>

```

const Component = () => {
  // 모달이 화면에 렌더링 중인지 
  const [isOpen, setIsOpen] = useState(false);
  
  // 닫히는 애니메이션이 실행 중인지
  const [isClosing, setIsClosing] = useState(false);

  const handleOpen = () => {
    setIsOpen(true);
    setIsClosing(false);
  };

  const handleClose = () => {
    setIsClosing(true); 
    
  
    setTimeout(() => {
      setIsOpen(false);
      setIsClosing(false); 
    }, 100); 
  };

  const handleConfirm = () => {
    console.log('확인 버튼 ~');
    handleClose();
  };

  return (
    <>
      <button onClick={handleOpen}>모달 열기 버튼</button>

      {/* isOpen이 true일 때만 모달 렌더링 */}
      {isOpen && (
        <AlertModal
          title="대화창을 닫으시겠습니까?"
          description="대화창을 닫을시 모든 대화 내역은 삭제됩니다."
          onClose={handleClose}    // 취소/닫기 버튼
          onConfirm={handleConfirm} // 확인 버튼
          isClosing={isClosing}    // 애니메이션 제어 Prop
        />
      )}
    </>
  );
};
export default Component;

```

</details>
<!--
## 👀 To Reviewer
-->


## 📸 Screenshot

https://github.com/user-attachments/assets/5cd62bd3-6dfc-4ad4-819b-3d4f6af0ab64


