### PR TITLE
Fix(client): quill 콘솔 오류 해결

### DIFF
--- a/apps/client/src/features/memo/libs/quill-register.ts
+++ b/apps/client/src/features/memo/libs/quill-register.ts
@@ -15,7 +15,7 @@ interface BlockEmbedConstructor {
 
 const INIT_KEY = '__clustar_quill_register_v1__';
 
-export const ensureQuillRegistered = () => {
+const ensureQuillRegistered = () => {
   // ✅ HMR/중복 번들에서도 1회만 보장
   const g = globalThis as unknown as Record<string, unknown>;
   if (g[INIT_KEY]) return;
@@ -35,3 +35,8 @@ export const ensureQuillRegistered = () => {
 
   g[INIT_KEY] = true;
 };
+
+// ✅ 모듈 로드 시점에 즉시 등록 (ReactQuill 렌더링 전에 실행됨)
+ensureQuillRegistered();
+
+export { ensureQuillRegistered };

--- a/apps/client/src/features/memo/ui/input-content/input-content.tsx
+++ b/apps/client/src/features/memo/ui/input-content/input-content.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import ReactQuill from 'react-quill-new';
 
+import '../../libs/quill-register';
+
 import { memoQuillFormats, memoQuillModules } from '../../libs/quill-config';
-import { ensureQuillRegistered } from '../../libs/quill-register';
 
 import * as styles from './input-content.css';
 
@@ -12,10 +13,6 @@ interface InputContnentProps {
 }
 
 const InputContent = ({ value, onChange }: InputContnentProps) => {
-  useEffect(() => {
-    ensureQuillRegistered();
-  }, []);
-
   const modules = useMemo(() => memoQuillModules, []);
   const formats = useMemo(() => [...memoQuillFormats], []);
 


### PR DESCRIPTION
## 📌 Summary

> #162

**quill 콘솔 오류를 해결했습니다!!!**

## 📚 Tasks
- Quill 등록 타이밍 이슈 해결

## 🔍 Describe
### 문제 상황
> Quill 커스텀 블롯(DividerBlot)과 마크다운 단축키 모듈이 제대로 등록되지 않는 문제가 발생했습니다.

### 원인
- `ensureQuillRegistered` 함수가 React 컴포넌트의 `useEffect` 내에서 호출되고 있었습니다.
- 이로 인해 `ReactQuill` 컴포넌트가 렌더링된 **후**에 Quill 등록이 시도되었습니다.
- Quill은 `ReactQuill` 컴포넌트가 렌더링되기 **전**에 등록되어야 합니다.
- 등록 타이밍 문제로 인해 커스텀 블롯과 모듈이 인식되지 않아 에러가 발생했습니다.

### 변경 사항
1. **`quill-register.ts`**
   - `ensureQuillRegistered` 함수를 모듈 로드 시점에 즉시 실행하도록 변경
   - 모듈이 import되는 순간 Quill 등록이 완료되도록 보장
2. **`input-content.tsx`**
   - `useEffect`에서 `ensureQuillRegistered` 호출 제거
   - 모듈 import만으로 등록이 완료되도록 변경 (`import '../../libs/quill-register'`)

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
