### PR TITLE
Fix(Client): axios 버전 업데이트

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,7 +20,7 @@
     "@sentry/react": "^10.32.1",
     "@tanstack/react-query": "^5.90.16",
     "@xyflow/react": "^12.10.0",
-    "axios": "^1.13.2",
+    "axios": "^1.15.0",
     "quill": "^2.0.3",
     "quill-markdown-shortcuts": "^0.0.10",
     "react": "catalog:react-core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^12.10.0
         version: 12.10.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       axios:
-        specifier: ^1.13.2
-        version: 1.13.2
+        specifier: ^1.15.0
+        version: 1.15.0
       quill:
         specifier: ^2.0.3
         version: 2.0.3
@@ -3250,10 +3250,10 @@ packages:
       }
     engines: { node: '>=4' }
 
-  axios@1.13.2:
+  axios@1.15.0:
     resolution:
       {
-        integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==,
+        integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==,
       }
 
   balanced-match@1.0.2:
@@ -6497,6 +6497,13 @@ packages:
       {
         integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
       }
+
+  proxy-from-env@2.1.0:
+    resolution:
+      {
+        integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==,
+      }
+    engines: { node: '>=10' }
 
   punycode@2.3.1:
     resolution:
@@ -9943,11 +9950,11 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios@1.13.2:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -11980,6 +11987,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## 📌 Summary

> 관련 있는 Issue를 태그해주세요. (e.g. > - #100)
> - #226 
_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._
axios의 보안 문제에 따른 axios 버전 업데이트

## 📚 Tasks

- axios 버전 업데이트

## 🔍 Describe

[axios 깃허브](https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx)
> Axios 라이브러리에서 발생하는 "가젯(Gadget)" 공격 체인 취약점이다. 서드파티 의존성 패키지에서 발생한 프로토타입 오염(Prototype Pollution)을 원격 코드 실행(RCE)이나 전체 클라우드 권한 탈취(AWS IMDSv2 우회)로 에스컬레이션(확장)할 수 있는 치명적인 결함이다.

>Axios 자체적으로 프로토타입 오염을 방지하는 패치는 존재하지만, 애플리케이션 내의 다른 라이브러리에서 오염이 발생했을 때 Axios가 공격의 도구(가젯)로 악용되는 취약점은 여전히 남아있었다. 이는 Axios 내부에 기본적으로 존재하는 SSRF 기능과 HTTP 헤더 무결성 검증(Sanitization) 부재(CWE-113)가 결합되어 발생한다.

>심각도: 심각 (CVSS 9.9)
영향을 받는 버전: < 1.13.2
패치된 버전: >= 1.15.0
취약한 컴포넌트: lib/adapters/http.js (헤더 처리 로직)

이에 따라 axios 버전을 1.15.0으로 업데이트합니다.

