### PR TITLE
Feat(client): FilterListItem 컴포넌트 구현

### DIFF
--- a/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.css.ts
+++ b/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.css.ts
@@ -51,7 +51,7 @@ export const icon = style({
   margin: '0.4rem',
 });
 
-export const tag = style({
+export const tagText = style({
   width: '100%',
   ...themeVars.fontStyles.body_m_16,
   color: themeVars.color.grey800,

--- a/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.css.ts
+++ b/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.css.ts
@@ -1,0 +1,61 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@cds/ui';
+
+export const container = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    height: '3.2rem',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    selectors: {
+      '&:hover': {
+        backgroundColor: themeVars.color.grey100,
+      },
+    },
+  },
+
+  variants: {
+    relation: {
+      parent: {
+        width: '61.2rem',
+        position: 'relative',
+        '::after': {
+          content: '""',
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: '-0.4rem',
+          height: '1px',
+          backgroundColor: themeVars.color.grey100,
+          pointerEvents: 'none',
+        },
+      },
+      child: {
+        width: '58.6rem',
+      },
+      descendant: {
+        width: '55.4rem',
+      },
+    },
+  },
+});
+
+export const checkbox = style({
+  appearance: 'none',
+});
+
+export const icon = style({
+  margin: '0.4rem',
+});
+
+export const tag = style({
+  width: '100%',
+  ...themeVars.fontStyles.body_m_16,
+  color: themeVars.color.grey800,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+});

--- a/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
+++ b/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
@@ -6,14 +6,14 @@ type RelationTypes = 'parent' | 'child' | 'descendant';
 
 interface FilterListItemProps {
   relation: RelationTypes;
-  tag: string;
+  tagText: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
 }
 
 const FilterListItem = ({
   relation,
-  tag,
+  tagText,
   checked,
   onChange,
 }: FilterListItemProps) => {
@@ -31,7 +31,7 @@ const FilterListItem = ({
         size={24}
         aria-hidden="true"
       />
-      <span className={styles.tag}>{tag}</span>
+      <span className={styles.tagText}>{tagText}</span>
     </label>
   );
 };

--- a/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
+++ b/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
@@ -1,0 +1,38 @@
+import { Icon } from '@cds/icon';
+
+import * as styles from './filter-list-item.css';
+
+type RelationTypes = 'parent' | 'child' | 'descendant';
+
+interface FilterListItemProps {
+  relation: RelationTypes;
+  tag: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+const FilterListItem = ({
+  relation,
+  tag,
+  checked,
+  onChange,
+}: FilterListItemProps) => {
+  return (
+    <label className={styles.container({ relation })}>
+      <input
+        className={styles.checkbox}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <Icon
+        name={checked ? 'ic_checkbox_on' : 'ic_checkbox_off'}
+        className={styles.icon}
+        size={24}
+      />
+      <span className={styles.tag}>{tag}</span>
+    </label>
+  );
+};
+
+export default FilterListItem;

--- a/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
+++ b/apps/client/src/pages/memo/components/filter-list-item/filter-list-item.tsx
@@ -29,6 +29,7 @@ const FilterListItem = ({
         name={checked ? 'ic_checkbox_on' : 'ic_checkbox_off'}
         className={styles.icon}
         size={24}
+        aria-hidden="true"
       />
       <span className={styles.tag}>{tag}</span>
     </label>


### PR DESCRIPTION
## 📌 Summary

> - #243

메모 필터 목록에서 관계(부모/자식/자손)별 태그를 표시하고 체크 상태를 토글할 수 있는 `FilterListItem` 컴포넌트를 구현

## 📚 Tasks

- `FilterListItem` 컴포넌트 구현 (`relation`, `tag`, `checked`, `onChange` props)
- relation(parent/child/descendant)에 따라 들여쓰기 폭이 다른 vanilla-extract recipe variant 추가

## 🔍 Describe

- 체크 상태는 컴포넌트 내부에서 관리하지 않고 `checked`/`onChange` props로 제어하는 controlled 컴포넌트로 구현했어요.
- 추후 여러 개의 `FilterListItem`을 렌더링하는 상위 컴포넌트가 제출 로직을 담당하는 구조로 구현하려고 해요.
- `relation`별 너비(parent/child/descendant)를 vanilla-extract `recipe`의 variant로 분리해 들여쓰기 단계를 표현했어요.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->


## 📸 Screenshot

<img width="1121" height="866" alt="image" src="https://github.com/user-attachments/assets/838684aa-057a-42e7-af6a-c27009631c5c" />