### PR TITLE
Chore(client, cds-ui): tag API 스펙 변경 반영 및 네이밍 통일

### DIFF
--- a/apps/client/src/pages/ai-results/apis/queries.ts
+++ b/apps/client/src/pages/ai-results/apis/queries.ts
@@ -42,25 +42,25 @@ const getAIMemo = async (
 };
 
 const getMemoTotalCount = async (
-  labelIds?: number[],
+  tagIds?: number[],
 ): Promise<number | undefined> => {
   const response = await api.get<AiMemoResponse>(AI_END_POINT.GET, {
     params: {
-      labelIds,
+      tagIds,
       size: 1,
     },
   });
   return response.data.data?.totalCount;
 };
 
-export const useGetMemoTotalCount = (labelIds?: number[]) => {
+export const useGetMemoTotalCount = (tagIds?: number[]) => {
   return useQuery({
     queryKey: [
       ...AI_MEMO_KEY.ALL,
       'totalCount',
-      ...(labelIds ? [{ labelIds }] : []),
+      ...(tagIds ? [{ tagIds }] : []),
     ],
-    queryFn: () => getMemoTotalCount(labelIds),
+    queryFn: () => getMemoTotalCount(tagIds),
   });
 };
 

--- a/apps/client/src/pages/all-memo/apis/end-point.ts
+++ b/apps/client/src/pages/all-memo/apis/end-point.ts
@@ -2,6 +2,6 @@ export const ALL_MEMO_END_POIINT = {
   GET: 'api/v1/memo',
 };
 
-export const LABEL_END_POINT = {
+export const TAG_END_POINT = {
   GET: 'api/v1/tag',
 };

--- a/apps/client/src/pages/all-memo/apis/end-point.ts
+++ b/apps/client/src/pages/all-memo/apis/end-point.ts
@@ -3,5 +3,5 @@ export const ALL_MEMO_END_POIINT = {
 };
 
 export const LABEL_END_POINT = {
-  GET: 'api/v1/label',
+  GET: 'api/v1/tag',
 };

--- a/apps/client/src/pages/all-memo/apis/queries.ts
+++ b/apps/client/src/pages/all-memo/apis/queries.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { api } from '@shared/apis/instance';
 import { components, paths } from '@shared/types/schema';
 
-import { ALL_MEMO_END_POIINT, LABEL_END_POINT } from './end-point';
+import { ALL_MEMO_END_POIINT, TAG_END_POINT } from './end-point';
 import { ALL_MEMO_KEY, TAG_KEY } from './query-key';
 import { type AllMemoResponse } from './type';
 
@@ -28,13 +28,13 @@ const getMemosFromResponse = (
 };
 
 const getAllMemo = async (
-  labelIds?: number[],
+  tagIds?: number[],
   cursor?: MemoCursor,
   size = 20,
 ): Promise<AllMemoResponse> => {
   const response = await api.get<AllMemoResponse>(ALL_MEMO_END_POIINT.GET, {
     params: {
-      labelIds,
+      tagIds,
       cursorCreatedAt: cursor?.cursorCreatedAt,
       cursorMemoId: cursor?.cursorMemoId,
       size,
@@ -44,30 +44,30 @@ const getAllMemo = async (
 };
 
 const getMemoTotalCount = async (
-  labelIds?: number[],
+  tagIds?: number[],
 ): Promise<number | undefined> => {
   const response = await api.get<AllMemoResponse>(ALL_MEMO_END_POIINT.GET, {
     params: {
-      labelIds,
+      tagIds,
       size: 1,
     },
   });
   return response.data.data?.totalCount;
 };
 
-export const useGetMemoTotalCount = (labelIds?: number[]) => {
+export const useGetMemoTotalCount = (tagIds?: number[]) => {
   return useQuery({
     queryKey: [
       ...ALL_MEMO_KEY.ALL,
       'totalCount',
-      ...(labelIds ? [{ labelIds }] : []),
+      ...(tagIds ? [{ tagIds }] : []),
     ],
-    queryFn: () => getMemoTotalCount(labelIds),
+    queryFn: () => getMemoTotalCount(tagIds),
     refetchOnMount: 'always', // 페이지로 돌아왔을 때 항상 refetch (staleTime 무시)
   });
 };
 
-export const useGetAllMemo = (labelIds?: number[], size = 20) => {
+export const useGetAllMemo = (tagIds?: number[], size = 20) => {
   return useInfiniteQuery<
     AllMemoResponse,
     Error,
@@ -75,8 +75,8 @@ export const useGetAllMemo = (labelIds?: number[], size = 20) => {
     ReturnType<typeof ALL_MEMO_KEY.GET>,
     MemoCursor
   >({
-    queryKey: ALL_MEMO_KEY.GET(labelIds),
-    queryFn: ({ pageParam }) => getAllMemo(labelIds, pageParam, size),
+    queryKey: ALL_MEMO_KEY.GET(tagIds),
+    queryFn: ({ pageParam }) => getAllMemo(tagIds, pageParam, size),
     getNextPageParam: (lastPage) => {
       const memos = getMemosFromResponse(lastPage);
       const last = memos[memos.length - 1];
@@ -94,18 +94,18 @@ export const useGetAllMemo = (labelIds?: number[], size = 20) => {
   });
 };
 
-type LabelListResponse = components['schemas']['LabelListResponse'];
-type ApiLabelResponse =
+type TagListResponse = components['schemas']['TagListResponse'];
+type ApiTagResponse =
   paths['/api/v1/tag']['get']['responses']['200']['content']['*/*'];
 
-const getAllLabels = async (): Promise<LabelListResponse['tags']> => {
-  const response = await api.get<ApiLabelResponse>(LABEL_END_POINT.GET);
+const getAllTags = async (): Promise<TagListResponse['tags']> => {
+  const response = await api.get<ApiTagResponse>(TAG_END_POINT.GET);
   return response.data.data?.tags ?? [];
 };
 
-export const useGetLabel = () => {
+export const useGetTag = () => {
   return useQuery({
     queryKey: TAG_KEY.GET(),
-    queryFn: () => getAllLabels(),
+    queryFn: () => getAllTags(),
   });
 };

--- a/apps/client/src/pages/all-memo/apis/queries.ts
+++ b/apps/client/src/pages/all-memo/apis/queries.ts
@@ -96,11 +96,11 @@ export const useGetAllMemo = (labelIds?: number[], size = 20) => {
 
 type LabelListResponse = components['schemas']['LabelListResponse'];
 type ApiLabelResponse =
-  paths['/api/v1/label']['get']['responses']['200']['content']['*/*'];
+  paths['/api/v1/tag']['get']['responses']['200']['content']['*/*'];
 
-const getAllLabels = async (): Promise<LabelListResponse['labels']> => {
+const getAllLabels = async (): Promise<LabelListResponse['tags']> => {
   const response = await api.get<ApiLabelResponse>(LABEL_END_POINT.GET);
-  return response.data.data?.labels ?? [];
+  return response.data.data?.tags ?? [];
 };
 
 export const useGetLabel = () => {

--- a/apps/client/src/pages/all-memo/apis/queries.ts
+++ b/apps/client/src/pages/all-memo/apis/queries.ts
@@ -4,7 +4,7 @@ import { api } from '@shared/apis/instance';
 import { components, paths } from '@shared/types/schema';
 
 import { ALL_MEMO_END_POIINT, LABEL_END_POINT } from './end-point';
-import { ALL_MEMO_KEY, LABEL_KEY } from './query-key';
+import { ALL_MEMO_KEY, TAG_KEY } from './query-key';
 import { type AllMemoResponse } from './type';
 
 type MemoCursor =
@@ -105,7 +105,7 @@ const getAllLabels = async (): Promise<LabelListResponse['tags']> => {
 
 export const useGetLabel = () => {
   return useQuery({
-    queryKey: LABEL_KEY.GET(),
+    queryKey: TAG_KEY.GET(),
     queryFn: () => getAllLabels(),
   });
 };

--- a/apps/client/src/pages/all-memo/apis/query-key.ts
+++ b/apps/client/src/pages/all-memo/apis/query-key.ts
@@ -1,9 +1,9 @@
 export const ALL_MEMO_KEY = {
   ALL: ['all/memos'],
-  GET: (labelIds?: number[]) => [
+  GET: (tagIds?: number[]) => [
     ...ALL_MEMO_KEY.ALL,
     'get',
-    ...(labelIds ? [{ labelIds }] : []),
+    ...(tagIds ? [{ tagIds }] : []),
   ],
 };
 

--- a/apps/client/src/pages/all-memo/apis/query-key.ts
+++ b/apps/client/src/pages/all-memo/apis/query-key.ts
@@ -7,7 +7,7 @@ export const ALL_MEMO_KEY = {
   ],
 };
 
-export const LABEL_KEY = {
-  ALL: ['labels'],
-  GET: () => [...LABEL_KEY.ALL, 'get'],
+export const TAG_KEY = {
+  ALL: ['tags'],
+  GET: () => [...TAG_KEY.ALL, 'get'],
 };

--- a/apps/client/src/pages/all-memo/apis/type.ts
+++ b/apps/client/src/pages/all-memo/apis/type.ts
@@ -4,4 +4,4 @@ export type AllMemoResponse =
   paths['/api/v1/memo']['get']['responses']['200']['content']['*/*'];
 
 export type LabelResponse =
-  paths['/api/v1/label']['get']['responses']['200']['content']['*/*'];
+  paths['/api/v1/tag']['get']['responses']['200']['content']['*/*'];

--- a/apps/client/src/pages/all-memo/apis/type.ts
+++ b/apps/client/src/pages/all-memo/apis/type.ts
@@ -3,5 +3,5 @@ import { paths } from '@shared/types/schema';
 export type AllMemoResponse =
   paths['/api/v1/memo']['get']['responses']['200']['content']['*/*'];
 
-export type LabelResponse =
+export type TagResponse =
   paths['/api/v1/tag']['get']['responses']['200']['content']['*/*'];

--- a/apps/client/src/pages/label/label-page.tsx
+++ b/apps/client/src/pages/label/label-page.tsx
@@ -3,46 +3,46 @@ import { useParams } from 'react-router';
 
 import {
   useGetAllMemo,
-  useGetLabel,
   useGetMemoTotalCount,
+  useGetTag,
 } from '@pages/all-memo/apis/queries';
 
 import MemoListView from '@shared/components/memo-list-view/memo-list-view';
 
-const LabelPage = () => {
-  const { labelId } = useParams<{ labelId?: string }>();
-  const { data: labels = [] } = useGetLabel();
+const TagPage = () => {
+  const { tagId } = useParams<{ tagId?: string }>();
+  const { data: tags = [] } = useGetTag();
 
-  const labelMeta = useMemo(() => {
-    if (!labelId) return undefined;
+  const tagMeta = useMemo(() => {
+    if (!tagId) return undefined;
 
-    const numericLabelId = Number(labelId);
-    if (isNaN(numericLabelId)) return undefined;
+    const numericTagId = Number(tagId);
+    if (isNaN(numericTagId)) return undefined;
 
-    const label = labels.find((l) => l.labelId === numericLabelId);
-    if (!label) return undefined;
+    const tag = tags.find((t) => t.tagId === numericTagId);
+    if (!tag) return undefined;
 
     return {
-      id: label.labelId ?? 0,
-      text: label.name ?? '',
+      id: tag.tagId ?? 0,
+      text: tag.name ?? '',
     };
-  }, [labelId, labels]);
+  }, [tagId, tags]);
 
   const {
-    data: labeledMemos,
+    data: taggedMemos,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetAllMemo(labelMeta ? [labelMeta.id] : undefined);
+  } = useGetAllMemo(tagMeta ? [tagMeta.id] : undefined);
 
   const { data: totalCount } = useGetMemoTotalCount(
-    labelMeta ? [labelMeta.id] : undefined,
+    tagMeta ? [tagMeta.id] : undefined,
   );
 
   return (
     <MemoListView
-      title={labelMeta?.text}
-      initialMemos={labeledMemos}
+      title={tagMeta?.text}
+      initialMemos={taggedMemos}
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       fetchNextPage={fetchNextPage}
@@ -51,4 +51,4 @@ const LabelPage = () => {
   );
 };
 
-export default LabelPage;
+export default TagPage;

--- a/apps/client/src/pages/new-memo/components/memo-input/memo-input.tsx
+++ b/apps/client/src/pages/new-memo/components/memo-input/memo-input.tsx
@@ -189,7 +189,7 @@ const MemoInput = () => {
     const request: MemoCreateRequest = {
       title: selectedDraft.title,
       content: htmlToMarkdown(selectedDraft.contents),
-      labelNames: selectedDraft.labels.map((l) => l.text),
+      tagNames: selectedDraft.labels.map((l) => l.text),
     };
 
     createMemo(request, {

--- a/apps/client/src/router/path.ts
+++ b/apps/client/src/router/path.ts
@@ -5,7 +5,7 @@ export const PATH = {
   NEW_MEMO: '/',
   ALL_MEMO: '/all-memo',
   AI_RESULTS: '/ai-results',
-  LABEL: '/label/:labelId',
+  TAG: '/tag/:tagId',
 } as const;
 
 export type Routes = (typeof PATH)[keyof typeof PATH];

--- a/apps/client/src/router/router.tsx
+++ b/apps/client/src/router/router.tsx
@@ -64,7 +64,7 @@ export const router = createBrowserRouter([
                 Component: AiResultsPage,
               },
               {
-                path: PATH.LABEL,
+                path: PATH.TAG,
                 Component: LabelPage,
               },
             ],

--- a/apps/client/src/shared/components/card/card.tsx
+++ b/apps/client/src/shared/components/card/card.tsx
@@ -9,7 +9,7 @@ import * as styles from './card.css';
 
 // TODO: Tag 백엔드 타입에 맞게 변경
 type TagType = {
-  labelId?: number;
+  tagId?: number;
   name?: string;
 };
 
@@ -47,7 +47,7 @@ const Card = ({
           {tagList.length > 0 ? (
             tagList.map((tag) => (
               <Label
-                key={tag.labelId}
+                key={tag.tagId}
                 labelSize="sm"
                 labelColor="blue"
                 labelText={tag.name ?? ''}

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
@@ -131,7 +131,7 @@ export const iconContainer = style({
   position: 'relative',
 });
 
-export const labelContainer = style({
+export const tagContainer = style({
   position: 'relative',
   width: '3.6rem',
   height: '3.6rem',
@@ -155,7 +155,7 @@ export const floatingMenu = style({
   opacity: 0,
 
   selectors: {
-    [`${iconContainer}:hover &, ${foldingBtn}:hover &, ${labelContainer}:hover &`]:
+    [`${iconContainer}:hover &, ${foldingBtn}:hover &, ${tagContainer}:hover &`]:
       {
         visibility: 'visible',
         opacity: 1,
@@ -163,7 +163,7 @@ export const floatingMenu = style({
   },
 });
 
-export const label = recipe({
+export const tag = recipe({
   base: {
     ...textBaseStyle,
     padding: '5.6rem 0 1.2rem 0',
@@ -179,7 +179,7 @@ export const label = recipe({
   },
 });
 
-export const labelList = recipe({
+export const tagList = recipe({
   base: {
     display: 'flex',
     flexDirection: 'column',

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.tsx
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@cds/icon';
 import { IconName } from '@cds/icon';
 import { SidebarIcon, SidebarPannel, SideBarProfile, Tooltip } from '@cds/ui';
 
-import { useGetLabel } from '@pages/all-memo/apis/queries';
+import { useGetTag } from '@pages/all-memo/apis/queries';
 
 import { useGetUserInfo } from '@shared/apis/user/queries';
 
@@ -15,17 +15,17 @@ import * as styles from './sidebar.css';
 const MENU_ITEMS = [
   {
     id: 'new',
-    label: '새 메모',
+    tag: '새 메모',
     icon: 'ic_newmemo',
     activeIcon: 'ic_newmemo_blue',
   },
   {
     id: 'all',
-    label: '전체 메모',
+    tag: '전체 메모',
     icon: 'ic_allmemo',
     activeIcon: 'ic_allmemo_blue',
   },
-  { id: 'ai', label: 'AI 기록', icon: 'ic_ai', activeIcon: 'ic_ai_blue_36' },
+  { id: 'ai', tag: 'AI 기록', icon: 'ic_ai', activeIcon: 'ic_ai_blue_36' },
 ] as const;
 
 const MENU_PATH: Record<string, string> = {
@@ -47,7 +47,7 @@ const Sidebar = () => {
   const [isHover, setIsHover] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const { data: userInfo } = useGetUserInfo();
-  const { data: labels = [] } = useGetLabel();
+  const { data: tags = [] } = useGetTag();
 
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -56,13 +56,13 @@ const Sidebar = () => {
     if (pathname === PATH.NEW_MEMO) return 'new';
     if (pathname.startsWith(PATH.AI_RESULTS)) return 'ai';
     if (pathname.startsWith(PATH.ALL_MEMO)) return 'all';
-    const labelMatch = matchPath(PATH.LABEL, pathname);
-    if (labelMatch?.params.labelId) return labelMatch.params.labelId;
+    const tagMatch = matchPath(PATH.TAG, pathname);
+    if (tagMatch?.params.tagId) return tagMatch.params.tagId;
     return '';
   }, [pathname]);
 
   const handleSelect = (id: string) => {
-    const path = MENU_PATH[id] ?? `/label/${id}`;
+    const path = MENU_PATH[id] ?? `/tag/${id}`;
     navigate(path);
   };
 
@@ -70,21 +70,21 @@ const Sidebar = () => {
     setIsExpanded((prev) => !prev);
   };
 
-  const labelItems = useMemo(() => {
-    return labels.map((label) => ({
-      id: String(label.labelId ?? ''),
-      label: label.name ?? '',
+  const tagItems = useMemo(() => {
+    return tags.map((tag) => ({
+      id: String(tag.tagId ?? ''),
+      tag: tag.name ?? '',
       icon: 'ic_label' as IconName,
       activeIcon: 'ic_label_blue' as IconName,
     }));
-  }, [labels]);
+  }, [tags]);
 
   const processedMenuItems = MENU_ITEMS.map((item) => ({
     ...item,
     ...getIconState(item, selectedId),
   }));
 
-  const processedLabelItems = labelItems.map((item) => ({
+  const processedTagItems = tagItems.map((item) => ({
     ...item,
     ...getIconState(item, selectedId),
   }));
@@ -139,7 +139,7 @@ const Sidebar = () => {
 
       <span className={styles.menu({ expanded: isExpanded })}>메뉴</span>
       <div className={styles.menuList({ expanded: isExpanded })}>
-        {processedMenuItems.map(({ id, label, isActive, iconName }) =>
+        {processedMenuItems.map(({ id, tag, isActive, iconName }) =>
           isExpanded ? (
             <SidebarPannel
               key={id}
@@ -147,7 +147,7 @@ const Sidebar = () => {
               onClick={() => handleSelect(id)}
               icon={<Icon name={iconName} size={36} />}
             >
-              {label}
+              {tag}
             </SidebarPannel>
           ) : (
             <div key={id} className={styles.iconContainer}>
@@ -157,33 +157,33 @@ const Sidebar = () => {
                 icon={<Icon name={iconName} size={36} />}
               />
               <div className={styles.floatingMenu}>
-                <Tooltip title={label} />
+                <Tooltip title={tag} />
               </div>
             </div>
           ),
         )}
       </div>
 
-      <span className={styles.label({ expanded: isExpanded })}>라벨</span>
-      <div className={styles.labelList({ expanded: isExpanded })}>
+      <span className={styles.tag({ expanded: isExpanded })}>라벨</span>
+      <div className={styles.tagList({ expanded: isExpanded })}>
         {isExpanded ? (
-          processedLabelItems.map(({ id, label, isActive, iconName }) => (
+          processedTagItems.map(({ id, tag, isActive, iconName }) => (
             <SidebarPannel
               key={id}
               isSelected={isActive}
               onClick={() => handleSelect(id)}
               icon={<Icon name={iconName} size={36} />}
             >
-              {label}
+              {tag}
             </SidebarPannel>
           ))
         ) : (
-          <div className={styles.labelContainer}>
+          <div className={styles.tagContainer}>
             <SidebarIcon
               isSelected={false}
               onClick={() => {
-                if (labelItems.length > 0) {
-                  handleSelect(labelItems[0].id);
+                if (tagItems.length > 0) {
+                  handleSelect(tagItems[0].id);
                 }
               }}
               icon={<Icon name="ic_label" size={36} />}

--- a/apps/client/src/shared/components/memo-list-view/components/memo-list/memo-card-grid.tsx
+++ b/apps/client/src/shared/components/memo-list-view/components/memo-list/memo-card-grid.tsx
@@ -24,15 +24,8 @@ const MemoCardItem = ({
   onDragStart,
   onDragEnd,
 }: MemoCardItemProps) => {
-  const {
-    memoId,
-    labelList,
-    title,
-    content,
-    fileCount,
-    imageCount,
-    createdAt,
-  } = memo;
+  const { memoId, tagList, title, content, fileCount, imageCount, createdAt } =
+    memo;
 
   const handleDragStart = () => {
     setTimeout(() => onDragStart(memoId ?? 0), 0);
@@ -47,7 +40,7 @@ const MemoCardItem = ({
     >
       <Card
         card={{
-          tagList: labelList ?? [],
+          tagList: tagList ?? [],
           title: title ?? '',
           content: content ?? '',
           fileCount: fileCount ?? 0,

--- a/apps/client/src/shared/components/memo-list-view/components/tree-view/apis/queries.ts
+++ b/apps/client/src/shared/components/memo-list-view/components/tree-view/apis/queries.ts
@@ -26,10 +26,10 @@ export const useReadMemoStructure = () => {
         memoId: memo.memoId ?? 0,
         title: memo.title ?? '',
         content: memo.content ?? '',
-        labelList:
-          memo.labelList?.map((label) => ({
-            labelId: label.labelId ?? 0,
-            name: label.name ?? '',
+        tagList:
+          memo.tagList?.map((tag) => ({
+            tagId: tag.tagId ?? 0,
+            name: tag.name ?? '',
           })) ?? [],
       }));
     },

--- a/apps/client/src/shared/components/memo-list-view/components/tree-view/components/tree-memo/apis/queries.ts
+++ b/apps/client/src/shared/components/memo-list-view/components/tree-view/components/tree-memo/apis/queries.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { api } from '@shared/apis/instance';
-import { LabelTextType } from '@shared/types/label-type';
+import { LabelTextType } from '@shared/types/label-type'; //추후 삭제할 타입이기에 현재는 유지
 
 import { MEMO_MODAL_END_POINT } from './end-point';
 import { MEMO_MODAL_KEY } from './query-key';
@@ -25,8 +25,8 @@ export interface SelectedMemoTypes {
     fileExtension: string;
     fileSize: string;
   }[];
-  labelList: {
-    labelId: number;
+  tagList: {
+    tagId: number;
     name: LabelTextType;
   }[];
   createdAt: string;
@@ -72,9 +72,9 @@ export const useDetailMemo = ({ memoId, enabled }: useDetailMemoProps) => {
           fileExtension: file.fileExtension ?? '',
           fileSize: file.fileSize ?? '',
         })),
-        labelList: (response.data?.labelList ?? []).map((label) => ({
-          labelId: label.labelId ?? 0,
-          name: (label.name ?? '') as LabelTextType,
+        tagList: (response.data?.tagList ?? []).map((tag) => ({
+          tagId: tag.tagId ?? 0,
+          name: (tag.name ?? '') as LabelTextType,
         })),
         createdAt: response.data?.createdAt ?? '',
         isAiGenerated: response.data?.isAiGenerated ?? false,

--- a/apps/client/src/shared/components/memo-list-view/components/tree-view/components/tree-memo/tree-memo.tsx
+++ b/apps/client/src/shared/components/memo-list-view/components/tree-view/components/tree-memo/tree-memo.tsx
@@ -15,7 +15,7 @@ interface TreeMemoProps {
 }
 
 const TreeMemo = ({ memo }: TreeMemoProps) => {
-  const { memoId, title, content, labelList } = memo;
+  const { memoId, title, content, tagList } = memo;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -27,13 +27,13 @@ const TreeMemo = ({ memo }: TreeMemoProps) => {
       content: '',
       images: [],
       files: [],
-      labelList: [],
+      tagList: [],
       createdAt: '',
       isAiGenerated: false,
       sourceMemoTitleList: [],
     },
   } = useDetailMemo({ memoId, enabled: isModalOpen });
-  const labelName = labelList[0]?.name ?? ('라벨없음' as LabelTextType);
+  const labelName = tagList[0]?.name ?? ('라벨없음' as LabelTextType);
   const labelColor = LABEL_COLOR_BY_TEXT[labelName as LabelTextType];
 
   const handleModalOpenChange = (open: boolean) => {

--- a/apps/client/src/shared/components/memo-list-view/components/tree-view/utils/convert-memos-data.ts
+++ b/apps/client/src/shared/components/memo-list-view/components/tree-view/utils/convert-memos-data.ts
@@ -3,18 +3,18 @@ import { StructureMemoTypes } from '@shared/types/memo-info-type';
 
 export const groupByLabelName = (memos: StructureMemoTypes[]) => {
   return memos.reduce<Record<string, StructureMemoTypes[]>>((acc, memo) => {
-    if (!memo.labelList || memo.labelList.length === 0) {
-      // labelList가 없거나 빈 배열일 때는 '라벨없음'으로 그룹화
+    if (!memo.tagList || memo.tagList.length === 0) {
+      // tagList가 없거나 빈 배열일 때는 '라벨없음'으로 그룹화
       if (!acc['라벨없음']) {
         acc['라벨없음'] = [];
       }
       acc['라벨없음'].push(memo);
     } else {
-      memo.labelList.forEach((label) => {
-        if (!acc[label.name]) {
-          acc[label.name] = [];
+      memo.tagList.forEach((tag) => {
+        if (!acc[tag.name]) {
+          acc[tag.name] = [];
         }
-        acc[label.name].push(memo);
+        acc[tag.name].push(memo);
       });
     }
     return acc;

--- a/apps/client/src/shared/components/modals/detail-modal/detail-modal.tsx
+++ b/apps/client/src/shared/components/modals/detail-modal/detail-modal.tsx
@@ -55,8 +55,8 @@ export interface SelectedMemoTypes {
     fileExtension: string;
     fileSize: string;
   }[];
-  labelList: {
-    labelId: number;
+  tagList: {
+    tagId: number;
     name: LabelTextType;
   }[];
   createdAt: string;
@@ -90,7 +90,7 @@ const DetailModal = ({
     content,
     images,
     files,
-    labelList,
+    tagList,
     createdAt,
     isAiGenerated,
     sourceMemoTitleList,
@@ -116,9 +116,9 @@ const DetailModal = ({
             <div>
               <LabelList
                 listType="modal"
-                labelItems={labelList.map((label) => ({
-                  id: String(label.labelId),
-                  text: label.name,
+                labelItems={tagList.map((tag) => ({
+                  id: String(tag.tagId),
+                  text: tag.name,
                 }))}
                 dateText={formatDateTime(createdAt)}
                 labelSize="lg"

--- a/apps/client/src/shared/types/memo-info-type.ts
+++ b/apps/client/src/shared/types/memo-info-type.ts
@@ -1,5 +1,5 @@
-export interface LabelListTypes {
-  labelId: number;
+export interface TagListTypes {
+  tagId: number;
   name: string;
 }
 
@@ -7,5 +7,5 @@ export interface StructureMemoTypes {
   memoId: number;
   title: string;
   content: string;
-  labelList: LabelListTypes[];
+  tagList: TagListTypes[];
 }

--- a/apps/client/src/shared/types/schema.d.ts
+++ b/apps/client/src/shared/types/schema.d.ts
@@ -4,6 +4,31 @@
  */
 
 export interface paths {
+  '/api/v1/tag/{tagId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * 태그 수정
+     * @description 태그 이름을 수정합니다.
+     */
+    put: operations['updateLabel'];
+    post?: never;
+    /**
+     * 태그 삭제
+     * @description 태그를 삭제합니다.
+     *     태그에 연결된 메모-태그 관계도 함께 정리합니다.
+     */
+    delete: operations['deleteLabel'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/oauth/reissue': {
     parameters: {
       query?: never;
@@ -42,6 +67,32 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/tag': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * [Legacy] 라벨 전체 조회
+     * @description 사용자가 생성한 모든 라벨 목록을 조회합니다.
+     *     메모에 사용된 라벨과 미사용 라벨을 모두 포함합니다.
+     */
+    get: operations['getAllLabels'];
+    put?: never;
+    /**
+     * 태그 생성
+     * @description 태그를 생성합니다.
+     *     parentTagId가 있으면 하위 태그로 생성하고, 없으면 부모 태그로 생성합니다.
+     */
+    post: operations['createLabel'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/memo': {
     parameters: {
       query?: never;
@@ -66,6 +117,27 @@ export interface paths {
      *     s3Key 정보를 함께 전달해야 합니다.
      */
     post: operations['createMemo'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/memo/recommendations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * AI 추천 메모
+     * @description 선택한 메모들과 의미적으로 유사한 메모를 최대 3개 추천합니다.
+     *     유사한 메모가 없을 경우 빈 결과와 안내 메시지를 반환합니다.
+     */
+    post: operations['recommendMemos'];
     delete?: never;
     options?: never;
     head?: never;
@@ -262,8 +334,8 @@ export interface paths {
     };
     /**
      * 구글 인증서버 토큰 검증 API
-     * @description 리다이렉트에서 AccessCode를 가지고 서버로 돌아오기 위한 엔드포인트입니다
-     *     해당 코드를 이용해서 사용자 정보를 파싱하고 액세스 토큰는 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다
+     * @description 구글 콜백에서 받은 인가코드로 로그인 처리를 한 뒤
+     *     프론트엔드의 콜백 URL로 code만 전달해 리다이렉트합니다.
      */
     get: operations['callback'];
     put?: never;
@@ -286,6 +358,46 @@ export interface paths {
      * @description 유저 정보를 조회하여, 이름, 이메일, 프로필이미지를 올립니다.
      */
     get: operations['getUserInfo'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/tag/parents': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 부모 태그 최대 10개 조회
+     * @description 사용자의 부모 태그 최대 10개를 생성일 내림차순으로 조회합니다.
+     */
+    get: operations['getParentLabels'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/tag/parents/{parentTagId}/children': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 부모 태그 기반 하위 태그 조회
+     * @description 부모 태그를 기준으로 자식 태그와 손자 태그를 계층 구조로 조회합니다.
+     */
+    get: operations['getChildAndGrandChildLabels'];
     put?: never;
     post?: never;
     delete?: never;
@@ -341,7 +453,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/label': {
+  '/api/v1/memo/search': {
     parameters: {
       query?: never;
       header?: never;
@@ -349,11 +461,12 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * 라벨 전체 조회
-     * @description 사용자가 생성한 모든 라벨 목록을 조회합니다.
-     *     메모에 사용된 라벨과 미사용 라벨을 모두 포함합니다.
+     * 메모 검색
+     * @description 검색어를 입력하면 최대 5개의 메모를 반환합니다.
+     *     - 텍스트 매칭(제목/본문/라벨) 최대 3개
+     *     - 의미 기반 벡터 검색 최대 2개
      */
-    get: operations['getAllLabels'];
+    get: operations['searchMemos'];
     put?: never;
     post?: never;
     delete?: never;
@@ -426,6 +539,27 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
+    LabelUpdateRequest: {
+      /**
+       * @description 태그 이름
+       * @example SOPT
+       */
+      name: string;
+    };
+    ApiResponseLabelSummaryResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['LabelSummaryResponse'];
+    };
+    LabelSummaryResponse: {
+      /** Format: int64 */
+      tagId?: number;
+      name?: string;
+      colorHex?: string;
+      /** Format: int64 */
+      parentId?: number;
+    };
     ApiResponseVoid: {
       /** Format: int32 */
       code?: number;
@@ -437,6 +571,19 @@ export interface components {
       code?: number;
       msg?: string;
       data?: string;
+    };
+    LabelCreateRequest: {
+      /**
+       * @description 태그 이름
+       * @example SOPT
+       */
+      name: string;
+      /**
+       * Format: int64
+       * @description 부모 태그 ID
+       * @example 1
+       */
+      parentTagId?: number;
     };
     /** @description 파일 메타데이터 목록 (선택) */
     FileRequest: {
@@ -546,6 +693,24 @@ export interface components {
        * @description 생성 시각
        */
       createdAt?: string;
+    };
+    MemoRecommendationRequest: {
+      memoIds: number[];
+    };
+    ApiResponseMemoRecommendationResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['MemoRecommendationResponse'];
+    };
+    MemoRecommendationItemResponse: {
+      /** Format: int64 */
+      memoId?: number;
+      title?: string;
+    };
+    MemoRecommendationResponse: {
+      results?: components['schemas']['MemoRecommendationItemResponse'][];
+      message?: string;
     };
     /** @description 메모 이미지/파일 업로드용 presigned URL 발급 요청 */
     MemoPresignedUrlRequest: {
@@ -734,16 +899,55 @@ export interface components {
       email?: string;
       profileImageUrl?: string;
     };
+    ApiResponseLabelListResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['LabelListResponse'];
+    };
+    LabelListResponse: {
+      tags?: components['schemas']['LabelResponse'][];
+    };
+    LabelResponse: {
+      /** Format: int64 */
+      tagId?: number;
+      name?: string;
+      colorHex?: string;
+      /** Format: int64 */
+      parentId?: number;
+    };
+    ApiResponseLabelParentListResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['LabelParentListResponse'];
+    };
+    LabelParentListResponse: {
+      tags?: components['schemas']['LabelSummaryResponse'][];
+    };
+    ApiResponseLabelHierarchyResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['LabelHierarchyResponse'];
+    };
+    LabelHierarchyResponse: {
+      parentTag?: components['schemas']['LabelSummaryResponse'];
+      childTags?: components['schemas']['LabelTreeResponse'][];
+    };
+    LabelTreeResponse: {
+      /** Format: int64 */
+      tagId?: number;
+      name?: string;
+      colorHex?: string;
+      /** Format: int64 */
+      parentId?: number;
+    };
     ApiResponseMemoListDashboardResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
       data?: components['schemas']['MemoListDashboardResponse'];
-    };
-    LabelResponse: {
-      /** Format: int64 */
-      labelId?: number;
-      name?: string;
     };
     MemoDashboardResponse: {
       /** Format: int64 */
@@ -898,14 +1102,25 @@ export interface components {
       /** @description 메모에 딸린 라벨 목록 */
       labelList?: components['schemas']['LabelResponse'][];
     };
-    ApiResponseLabelListResponse: {
+    ApiResponseMemoSearchResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
-      data?: components['schemas']['LabelListResponse'];
+      data?: components['schemas']['MemoSearchResponse'];
     };
-    LabelListResponse: {
-      labels?: components['schemas']['LabelResponse'][];
+    MemoSearchItemResponse: {
+      /** Format: int64 */
+      memoId?: number;
+      title?: string;
+      content?: string;
+      labelList?: components['schemas']['LabelResponse'][];
+      /** Format: date-time */
+      createdAt?: string;
+      /** @enum {string} */
+      searchType?: 'TEXT' | 'SEMANTIC';
+    };
+    MemoSearchResponse: {
+      results?: components['schemas']['MemoSearchItemResponse'][];
     };
     ApiResponseChatRoomListResponse: {
       /** Format: int32 */
@@ -937,6 +1152,54 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  updateLabel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        tagId: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LabelUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseLabelSummaryResponse'];
+        };
+      };
+    };
+  };
+  deleteLabel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        tagId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseString'];
+        };
+      };
+    };
+  };
   reissueToken: {
     parameters: {
       query?: never;
@@ -1069,6 +1332,50 @@ export interface operations {
         };
         content: {
           'application/json': unknown;
+        };
+      };
+    };
+  };
+  getAllLabels: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseLabelListResponse'];
+        };
+      };
+    };
+  };
+  createLabel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LabelCreateRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseLabelSummaryResponse'];
         };
       };
     };
@@ -1222,6 +1529,30 @@ export interface operations {
         };
         content: {
           'application/json': unknown;
+        };
+      };
+    };
+  };
+  recommendMemos: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemoRecommendationRequest'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseMemoRecommendationResponse'];
         };
       };
     };
@@ -1612,7 +1943,9 @@ export interface operations {
   callback: {
     parameters: {
       query: {
-        code: string;
+        params: {
+          [key: string]: string;
+        };
       };
       header?: never;
       path?: never;
@@ -1626,7 +1959,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseVoid'];
+          '*/*': Record<string, never>;
         };
       };
       400: {
@@ -1695,6 +2028,48 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['ApiResponseUserInfoResponse'];
+        };
+      };
+    };
+  };
+  getParentLabels: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseLabelParentListResponse'];
+        };
+      };
+    };
+  };
+  getChildAndGrandChildLabels: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        parentTagId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseLabelHierarchyResponse'];
         };
       };
     };
@@ -1875,9 +2250,11 @@ export interface operations {
       };
     };
   };
-  getAllLabels: {
+  searchMemos: {
     parameters: {
-      query?: never;
+      query: {
+        query: string;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -1890,7 +2267,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelListResponse'];
+          '*/*': components['schemas']['ApiResponseMemoSearchResponse'];
         };
       };
     };

--- a/apps/client/src/shared/types/schema.d.ts
+++ b/apps/client/src/shared/types/schema.d.ts
@@ -16,14 +16,14 @@ export interface paths {
      * 태그 수정
      * @description 태그 이름을 수정합니다.
      */
-    put: operations['updateLabel'];
+    put: operations['updateTag'];
     post?: never;
     /**
      * 태그 삭제
      * @description 태그를 삭제합니다.
      *     태그에 연결된 메모-태그 관계도 함께 정리합니다.
      */
-    delete: operations['deleteLabel'];
+    delete: operations['deleteTag'];
     options?: never;
     head?: never;
     patch?: never;
@@ -75,18 +75,18 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * [Legacy] 라벨 전체 조회
-     * @description 사용자가 생성한 모든 라벨 목록을 조회합니다.
-     *     메모에 사용된 라벨과 미사용 라벨을 모두 포함합니다.
+     * [Legacy] 태그 전체 조회
+     * @description 사용자가 생성한 모든 태그 목록을 조회합니다.
+     *     메모에 사용된 태그와 미사용 태그를 모두 포함합니다.
      */
-    get: operations['getAllLabels'];
+    get: operations['getAllTags'];
     put?: never;
     /**
      * 태그 생성
      * @description 태그를 생성합니다.
      *     parentTagId가 있으면 하위 태그로 생성하고, 없으면 부모 태그로 생성합니다.
      */
-    post: operations['createLabel'];
+    post: operations['createTag'];
     delete?: never;
     options?: never;
     head?: never;
@@ -103,7 +103,7 @@ export interface paths {
     /**
      * 메모 전체 조회(대시보드)
      * @description 메모를 전체 조회합니다.
-     *     - labelIds가 있으면 해당 라벨이 포함된 메모만 조회합니다.
+     *     - tagIds가 있으면 해당 태그가 포함된 메모만 조회합니다.
      *     - 커서 기반 페이지네이션을 지원합니다.
      *     - 각 메모는 대표 이미지 1개(presigned URL)와
      *       이미지/파일 개수 정보를 포함합니다.
@@ -175,7 +175,7 @@ export interface paths {
     /**
      * AI가 생성한 메모 전체 조회(대시보드)
      * @description AI가 생성한 메모를 전체 조회합니다.
-     *     - labelIds가 있으면 해당 라벨이 포함된 메모만 조회합니다.
+     *     - tagIds가 있으면 해당 태그가 포함된 메모만 조회합니다.
      *     - 커서 기반 페이지네이션을 지원합니다.
      *     - 각 메모는 대표 이미지 1개(presigned URL)와
      *       이미지/파일 개수 정보를 포함합니다.
@@ -304,6 +304,51 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/admin/memos/{memoId}/re-embed': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 특정 메모 재임베딩(수동 재시도)
+     * @description 특정 memoId 하나만 동기적으로 재임베딩합니다.
+     *     text/image/file은 서로 독립적으로 시도되어, 하나가 실패해도 나머지는 계속 진행됩니다.
+     *     타입별로 성공한 것만 해당 타입의 미해결 임베딩 실패 기록이 해결 처리됩니다.
+     *     (imageSucceeded/fileSucceeded가 null이면 해당 타입의 첨부가 없어 시도하지 않은 것입니다.)
+     */
+    post: operations['reEmbedOne'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/admin/memos/re-embed': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 전체 메모 재임베딩
+     * @description 삭제되지 않은 전체 메모를 대상으로 재임베딩 배치를 시작합니다.
+     *     비동기로 실행되며, 호출 즉시 시작 응답을 반환합니다.
+     *     메모별로 기존 벡터는 새 벡터 적재에 성공한 후에만 삭제됩니다.
+     */
+    post: operations['reEmbedAll'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/oauth/google': {
     parameters: {
       query?: never;
@@ -377,7 +422,7 @@ export interface paths {
      * 부모 태그 최대 10개 조회
      * @description 사용자의 부모 태그 최대 10개를 생성일 내림차순으로 조회합니다.
      */
-    get: operations['getParentLabels'];
+    get: operations['getParentTags'];
     put?: never;
     post?: never;
     delete?: never;
@@ -397,7 +442,7 @@ export interface paths {
      * 부모 태그 기반 하위 태그 조회
      * @description 부모 태그를 기준으로 자식 태그와 손자 태그를 계층 구조로 조회합니다.
      */
-    get: operations['getChildAndGrandChildLabels'];
+    get: operations['getChildAndGrandChildTags'];
     put?: never;
     post?: never;
     delete?: never;
@@ -418,7 +463,7 @@ export interface paths {
      * @description 하나의 메모를 상세조회 합니다.
      *     AI가 생성한 메모일 경우 선택한 메모의 ID를 리스트로 반환합니다.
      *     AI가 생성한 메모가 아닐 경우 선택한 메모가 없으므로 빈 리스트를 반환합니다.
-     *     라벨은 리스트의 앞부터 우선순위가 높은 순서 입니다.
+     *     태그는 리스트의 앞부터 우선순위가 높은 순서 입니다.
      */
     get: operations['getOneDetailMemo'];
     put?: never;
@@ -463,7 +508,7 @@ export interface paths {
     /**
      * 메모 검색
      * @description 검색어를 입력하면 최대 5개의 메모를 반환합니다.
-     *     - 텍스트 매칭(제목/본문/라벨) 최대 3개
+     *     - 텍스트 매칭(제목/본문/태그) 최대 3개
      *     - 의미 기반 벡터 검색 최대 2개
      */
     get: operations['searchMemos'];
@@ -487,6 +532,26 @@ export interface paths {
      * @description 로그인한 사용자의 최근 AI 채팅방을 조회합니다.
      */
     get: operations['findLatestChatRoomByUser'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/admin/memos/embedding-failures': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 미해결 임베딩 실패 목록 조회
+     * @description 재시도가 필요한(is_resolved=false) 임베딩 실패 기록을 조회합니다.
+     */
+    get: operations['getEmbeddingFailures'];
     put?: never;
     post?: never;
     delete?: never;
@@ -539,20 +604,20 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
-    LabelUpdateRequest: {
+    TagUpdateRequest: {
       /**
        * @description 태그 이름
        * @example SOPT
        */
       name: string;
     };
-    ApiResponseLabelSummaryResponse: {
+    ApiResponseTagSummaryResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
-      data?: components['schemas']['LabelSummaryResponse'];
+      data?: components['schemas']['TagSummaryResponse'];
     };
-    LabelSummaryResponse: {
+    TagSummaryResponse: {
       /** Format: int64 */
       tagId?: number;
       name?: string;
@@ -572,7 +637,7 @@ export interface components {
       msg?: string;
       data?: string;
     };
-    LabelCreateRequest: {
+    TagCreateRequest: {
       /**
        * @description 태그 이름
        * @example SOPT
@@ -657,14 +722,14 @@ export interface components {
        */
       content: string;
       /**
-       * @description 라벨 이름 목록
+       * @description 태그 이름 목록
        * @example [
        *       "SOPT",
        *       "교양",
        *       "레퍼런스"
        *     ]
        */
-      labelNames?: string[];
+      tagNames?: string[];
       /** @description 이미지 메타데이터 목록 (선택) */
       images?: components['schemas']['ImageRequest'][];
       /** @description 파일 메타데이터 목록 (선택) */
@@ -886,6 +951,28 @@ export interface components {
       aiResponse?: components['schemas']['MemoAiResponse'];
       evaluation?: components['schemas']['AiEvaluationResult'];
     };
+    ApiResponseReEmbeddingResultResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['ReEmbeddingResultResponse'];
+    };
+    ReEmbeddingResultResponse: {
+      /** Format: int64 */
+      memoId?: number;
+      textSucceeded?: boolean;
+      imageSucceeded?: boolean;
+      fileSucceeded?: boolean;
+    };
+    ApiResponseReEmbeddingStartedResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['ReEmbeddingStartedResponse'];
+    };
+    ReEmbeddingStartedResponse: {
+      message?: string;
+    };
     ApiResponseUserInfoResponse: {
       /** Format: int32 */
       code?: number;
@@ -899,16 +986,16 @@ export interface components {
       email?: string;
       profileImageUrl?: string;
     };
-    ApiResponseLabelListResponse: {
+    ApiResponseTagListResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
-      data?: components['schemas']['LabelListResponse'];
+      data?: components['schemas']['TagListResponse'];
     };
-    LabelListResponse: {
-      tags?: components['schemas']['LabelResponse'][];
+    TagListResponse: {
+      tags?: components['schemas']['TagResponse'][];
     };
-    LabelResponse: {
+    TagResponse: {
       /** Format: int64 */
       tagId?: number;
       name?: string;
@@ -916,26 +1003,26 @@ export interface components {
       /** Format: int64 */
       parentId?: number;
     };
-    ApiResponseLabelParentListResponse: {
+    ApiResponseTagParentListResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
-      data?: components['schemas']['LabelParentListResponse'];
+      data?: components['schemas']['TagParentListResponse'];
     };
-    LabelParentListResponse: {
-      tags?: components['schemas']['LabelSummaryResponse'][];
+    TagParentListResponse: {
+      tags?: components['schemas']['TagSummaryResponse'][];
     };
-    ApiResponseLabelHierarchyResponse: {
+    ApiResponseTagHierarchyResponse: {
       /** Format: int32 */
       code?: number;
       msg?: string;
-      data?: components['schemas']['LabelHierarchyResponse'];
+      data?: components['schemas']['TagHierarchyResponse'];
     };
-    LabelHierarchyResponse: {
-      parentTag?: components['schemas']['LabelSummaryResponse'];
-      childTags?: components['schemas']['LabelTreeResponse'][];
+    TagHierarchyResponse: {
+      parentTag?: components['schemas']['TagSummaryResponse'];
+      childTags?: components['schemas']['TagTreeResponse'][];
     };
-    LabelTreeResponse: {
+    TagTreeResponse: {
       /** Format: int64 */
       tagId?: number;
       name?: string;
@@ -964,7 +1051,7 @@ export interface components {
       isNew?: boolean;
       /** Format: date-time */
       createdAt?: string;
-      labelList?: components['schemas']['LabelResponse'][];
+      tagList?: components['schemas']['TagResponse'][];
     };
     MemoListDashboardResponse: {
       /** Format: int64 */
@@ -1050,8 +1137,8 @@ export interface components {
       images?: components['schemas']['ImageInfo'][];
       /** @description 첨부 파일 정보 목록 */
       files?: components['schemas']['FileInfo'][];
-      /** @description 메모에 딸린 라벨들 */
-      labelList?: components['schemas']['LabelResponse'][];
+      /** @description 메모에 딸린 태그들 */
+      tagList?: components['schemas']['TagResponse'][];
       /**
        * Format: date-time
        * @description 메모 생성 시각
@@ -1099,8 +1186,8 @@ export interface components {
        * @example 발박수 치며 날아 간다.
        */
       content?: string;
-      /** @description 메모에 딸린 라벨 목록 */
-      labelList?: components['schemas']['LabelResponse'][];
+      /** @description 메모에 딸린 태그 목록 */
+      tagList?: components['schemas']['TagResponse'][];
     };
     ApiResponseMemoSearchResponse: {
       /** Format: int32 */
@@ -1113,7 +1200,7 @@ export interface components {
       memoId?: number;
       title?: string;
       content?: string;
-      labelList?: components['schemas']['LabelResponse'][];
+      tagList?: components['schemas']['TagResponse'][];
       /** Format: date-time */
       createdAt?: string;
       /** @enum {string} */
@@ -1121,6 +1208,7 @@ export interface components {
     };
     MemoSearchResponse: {
       results?: components['schemas']['MemoSearchItemResponse'][];
+      message?: string;
     };
     ApiResponseChatRoomListResponse: {
       /** Format: int32 */
@@ -1143,6 +1231,22 @@ export interface components {
       msg?: string;
       data?: components['schemas']['ChatRoomResponse'];
     };
+    ApiResponseListEmbeddingFailureResponse: {
+      /** Format: int32 */
+      code?: number;
+      msg?: string;
+      data?: components['schemas']['EmbeddingFailureResponse'][];
+    };
+    EmbeddingFailureResponse: {
+      /** Format: int64 */
+      id?: number;
+      /** Format: int64 */
+      memoId?: number;
+      embeddingType?: string;
+      /** Format: date-time */
+      failedAt?: string;
+      errorMessage?: string;
+    };
   };
   responses: never;
   parameters: never;
@@ -1152,7 +1256,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  updateLabel: {
+  updateTag: {
     parameters: {
       query?: never;
       header?: never;
@@ -1163,7 +1267,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['LabelUpdateRequest'];
+        'application/json': components['schemas']['TagUpdateRequest'];
       };
     };
     responses: {
@@ -1173,12 +1277,12 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelSummaryResponse'];
+          '*/*': components['schemas']['ApiResponseTagSummaryResponse'];
         };
       };
     };
   };
-  deleteLabel: {
+  deleteTag: {
     parameters: {
       query?: never;
       header?: never;
@@ -1336,7 +1440,7 @@ export interface operations {
       };
     };
   };
-  getAllLabels: {
+  getAllTags: {
     parameters: {
       query?: never;
       header?: never;
@@ -1351,12 +1455,12 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelListResponse'];
+          '*/*': components['schemas']['ApiResponseTagListResponse'];
         };
       };
     };
   };
-  createLabel: {
+  createTag: {
     parameters: {
       query?: never;
       header?: never;
@@ -1365,7 +1469,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['LabelCreateRequest'];
+        'application/json': components['schemas']['TagCreateRequest'];
       };
     };
     responses: {
@@ -1375,7 +1479,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelSummaryResponse'];
+          '*/*': components['schemas']['ApiResponseTagSummaryResponse'];
         };
       };
     };
@@ -1383,7 +1487,7 @@ export interface operations {
   getMemos: {
     parameters: {
       query?: {
-        labelIds?: number[];
+        tagIds?: number[];
         cursorCreatedAt?: string;
         cursorMemoId?: number;
         size?: number;
@@ -1632,7 +1736,7 @@ export interface operations {
   getAiMemos: {
     parameters: {
       query?: {
-        labelIds?: number[];
+        tagIds?: number[];
         cursorCreatedAt?: string;
         cursorMemoId?: number;
         size?: number;
@@ -1874,6 +1978,48 @@ export interface operations {
       };
     };
   };
+  reEmbedOne: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        memoId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseReEmbeddingResultResponse'];
+        };
+      };
+    };
+  };
+  reEmbedAll: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseReEmbeddingStartedResponse'];
+        };
+      };
+    };
+  };
   redirectToGoogleAuth: {
     parameters: {
       query?: never;
@@ -2032,7 +2178,7 @@ export interface operations {
       };
     };
   };
-  getParentLabels: {
+  getParentTags: {
     parameters: {
       query?: never;
       header?: never;
@@ -2047,12 +2193,12 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelParentListResponse'];
+          '*/*': components['schemas']['ApiResponseTagParentListResponse'];
         };
       };
     };
   };
-  getChildAndGrandChildLabels: {
+  getChildAndGrandChildTags: {
     parameters: {
       query?: never;
       header?: never;
@@ -2069,7 +2215,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['ApiResponseLabelHierarchyResponse'];
+          '*/*': components['schemas']['ApiResponseTagHierarchyResponse'];
         };
       };
     };
@@ -2288,6 +2434,26 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['ApiResponseChatRoomResponse'];
+        };
+      };
+    };
+  };
+  getEmbeddingFailures: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['ApiResponseListEmbeddingFailureResponse'];
         };
       };
     };

--- a/packages/cds-ui/src/components/label-list/label-list.css.ts
+++ b/packages/cds-ui/src/components/label-list/label-list.css.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 

--- a/packages/cds-ui/src/components/label-list/label-list.stories.tsx
+++ b/packages/cds-ui/src/components/label-list/label-list.stories.tsx
@@ -1,4 +1,8 @@
-// label-list.stories.tsx
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { LabelTextType } from '../../constants/label-color-map';

--- a/packages/cds-ui/src/components/label-list/label-list.tsx
+++ b/packages/cds-ui/src/components/label-list/label-list.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import { CSSProperties } from 'react';
 
 import {

--- a/packages/cds-ui/src/components/label/label.css.ts
+++ b/packages/cds-ui/src/components/label/label.css.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '../../styles';

--- a/packages/cds-ui/src/components/label/label.stories.tsx
+++ b/packages/cds-ui/src/components/label/label.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test'; // 클릭 액션 감지를 위해 추가
 

--- a/packages/cds-ui/src/components/label/label.tsx
+++ b/packages/cds-ui/src/components/label/label.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 삭제 예정 파일
+ */
+// NOTE: 삭제 예정이지만 Tag 도입 밑작업에서 props 타입이 함께 변경되어
+// 타입 에러 방지를 위해 최소 범위만 수정
 import { LabelColorType } from '../../constants/label-color-map';
 
 import * as styles from './label.css';


### PR DESCRIPTION
## 📌 Summary

> - #263 

tag API 스펙 변경 반영 및 네이밍 통일을 진행했어요.

## 📚 Tasks

- DTO 클래스명 변경 요청
- openapi-typescript 스키마 타입 재생성
- tag API 레이어 및 응답 필드(labelList → tagList) 반영

## 🔍 Describe

서버에서 `label` → `tag`로 필드명이 변경되어 프론트에서도 이를 반영했어요.

- tag 도메인 API는 `tag`로 변경 완료
- DTO 클래스명이 변경되지 않아 Swagger 기반 `openapi-typescript` 생성 타입에 `Label`이 그대로 남아있던 문제는 서버에 변경 요청 후 수정 완료했어요

다만 클라이언트 내부(API 레이어, 도메인 타입, 라우팅)에는 여전히 `label`과 `tag` 네이밍이 혼재되어 있어요.
대규모 리디자인 반영으로 해당 코드 상당수가 곧 삭제되거나 크게 변경될 예정이라 이번 PR에서는 서버 응답 네이밍으로 인해 타입 에러가 발생하는 지점만 수정하고 나머지 통일은 리디자인 작업에 맡기도록 하겠습니다,,


## 👀 To Reviewer

필드명 잘 변경되었는지 확인해주시면 감사할 것 같아요 !

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
