### PR TITLE
Feat(client): MemoTab 컴포넌트 구현

### DIFF
--- a/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
@@ -5,11 +5,10 @@ import { themeVars } from '@cds/ui';
 
 export const container = recipe({
   base: {
+    position: 'relative',
     display: 'flex',
-    padding: '2rem 0.8rem 2rem 0.8rem',
     width: '18.8rem',
     justifyContent: 'flex-start',
-    gap: '1rem',
     alignItems: 'center',
     borderBottom: '2.5px solid transparent',
   },
@@ -36,16 +35,25 @@ export const icon = style({
   flexShrink: 0,
 });
 
-export const memoContainer = style({
+export const selectTab = style({
   display: 'flex',
   gap: '0.3rem',
   alignItems: 'center',
   minWidth: 0,
   flex: 1,
-  color: themeVars.color.grey500,
+  border: 'none',
+  backgroundColor: 'transparent',
+  padding: '2rem 0.8rem',
+  // closeTab 영역 3.2rem + 탭-닫기 버튼 간격 1rem
+  paddingRight: '4.2rem',
 });
 
-export const closeMemo = style({
+export const closeTab = style({
+  position: 'absolute',
+  top: '50%',
+  right: '0.8rem',
+  transform: 'translateY(-50%)',
+  zIndex: themeVars.zIndex.button,
   opacity: 0,
   borderRadius: '0.8rem',
   padding: '0.4rem',

--- a/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
@@ -55,12 +55,18 @@ export const closeTab = style({
   transform: 'translateY(-50%)',
   zIndex: themeVars.zIndex.button,
   opacity: 0,
+  pointerEvents: 'none',
   borderRadius: '0.8rem',
   padding: '0.4rem',
   backgroundColor: 'transparent',
   selectors: {
     [`${container.classNames.base}:hover &`]: {
       opacity: 1,
+      pointerEvents: 'auto',
+    },
+    [`${container.classNames.base}:focus-within &`]: {
+      opacity: 1,
+      pointerEvents: 'auto',
     },
     '&:hover': {
       backgroundColor: themeVars.color.grey100,

--- a/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
@@ -22,6 +22,7 @@ export const container = recipe({
       false: {
         selectors: {
           '&:hover': {
+            transition: 'border-bottom-color 0.2s ease',
             borderBottomColor: themeVars.color.grey500,
             color: themeVars.color.grey600,
           },
@@ -69,6 +70,7 @@ export const closeTab = style({
       pointerEvents: 'auto',
     },
     '&:hover': {
+      transition: 'background-color 0.2s ease',
       backgroundColor: themeVars.color.grey100,
     },
   },

--- a/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
@@ -1,0 +1,87 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@cds/ui';
+
+export const container = recipe({
+  base: {
+    display: 'flex',
+    padding: '2rem 0.8rem 2rem 0.8rem',
+    width: '18.8rem',
+    justifyContent: 'flex-start',
+    gap: '1rem',
+    alignItems: 'center',
+    borderBottom: '2.5px solid transparent',
+  },
+
+  variants: {
+    isSelected: {
+      true: {
+        borderBottomColor: themeVars.color.blue400,
+        color: themeVars.color.blue500,
+      },
+      false: {
+        selectors: {
+          '&:hover': {
+            borderBottomColor: themeVars.color.grey500,
+            color: themeVars.color.grey600,
+          },
+        },
+      },
+    },
+  },
+});
+
+export const icon = style({
+  flexShrink: 0,
+});
+
+export const memoContainer = style({
+  display: 'flex',
+  gap: '0.3rem',
+  alignItems: 'center',
+  minWidth: 0,
+  flex: 1,
+  color: themeVars.color.grey500,
+});
+
+export const closeMemo = style({
+  opacity: 0,
+  borderRadius: '0.8rem',
+  padding: '0.4rem',
+  backgroundColor: 'transparent',
+  selectors: {
+    [`${container.classNames.base}:hover &`]: {
+      opacity: 1,
+    },
+    '&:hover': {
+      backgroundColor: themeVars.color.grey100,
+    },
+  },
+});
+
+export const memoTitle = recipe({
+  base: {
+    color: themeVars.color.grey500,
+    ...themeVars.fontStyles.body_m_16,
+    minWidth: 0,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+
+  variants: {
+    isSelected: {
+      true: {
+        color: themeVars.color.blue500,
+      },
+      false: {
+        selectors: {
+          [`${container.classNames.base}:hover &`]: {
+            color: themeVars.color.grey600,
+          },
+        },
+      },
+    },
+  },
+});

--- a/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.css.ts
@@ -19,14 +19,12 @@ export const container = recipe({
         borderBottomColor: themeVars.color.blue400,
         color: themeVars.color.blue500,
       },
-      false: {
-        selectors: {
-          '&:hover': {
-            transition: 'border-bottom-color 0.2s ease',
-            borderBottomColor: themeVars.color.grey500,
-            color: themeVars.color.grey600,
-          },
-        },
+    },
+    isHoverActive: {
+      true: {
+        transition: 'border-bottom-color 0.2s ease',
+        borderBottomColor: themeVars.color.grey500,
+        color: themeVars.color.grey600,
       },
     },
   },
@@ -49,29 +47,32 @@ export const selectTab = style({
   paddingRight: '4.2rem',
 });
 
-export const closeTab = style({
-  position: 'absolute',
-  top: '50%',
-  right: '0.8rem',
-  transform: 'translateY(-50%)',
-  zIndex: themeVars.zIndex.button,
-  opacity: 0,
-  pointerEvents: 'none',
-  borderRadius: '0.8rem',
-  padding: '0.4rem',
-  backgroundColor: 'transparent',
-  selectors: {
-    [`${container.classNames.base}:hover &`]: {
-      opacity: 1,
-      pointerEvents: 'auto',
+export const closeTab = recipe({
+  base: {
+    position: 'absolute',
+    top: '50%',
+    right: '0.8rem',
+    transform: 'translateY(-50%)',
+    zIndex: themeVars.zIndex.button,
+    borderRadius: '0.8rem',
+    padding: '0.4rem',
+    backgroundColor: 'transparent',
+    selectors: {
+      [`${container.classNames.base}:focus-within &`]: {
+        opacity: 1,
+        pointerEvents: 'auto',
+      },
+      '&:hover': {
+        transition: 'background-color 0.2s ease',
+        backgroundColor: themeVars.color.grey100,
+      },
     },
-    [`${container.classNames.base}:focus-within &`]: {
-      opacity: 1,
-      pointerEvents: 'auto',
-    },
-    '&:hover': {
-      transition: 'background-color 0.2s ease',
-      backgroundColor: themeVars.color.grey100,
+  },
+
+  variants: {
+    isHovered: {
+      true: { opacity: 1, pointerEvents: 'auto' },
+      false: { opacity: 0, pointerEvents: 'none' },
     },
   },
 });
@@ -91,12 +92,10 @@ export const memoTitle = recipe({
       true: {
         color: themeVars.color.blue500,
       },
-      false: {
-        selectors: {
-          [`${container.classNames.base}:hover &`]: {
-            color: themeVars.color.grey600,
-          },
-        },
+    },
+    isHoverActive: {
+      true: {
+        color: themeVars.color.grey600,
       },
     },
   },

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -49,6 +49,7 @@ const MemoTab = ({
           onCloseTab();
         }}
         type="button"
+        aria-label={`${memoTitle} 탭 닫기`}
         className={styles.closeMemo}
       >
         <Icon name="ic_delete" size={24} />

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -51,7 +51,7 @@ const MemoTab = ({
         type="button"
         className={styles.closeMemo}
       >
-        <Icon name="ic_delete" size={32} />
+        <Icon name="ic_delete" size={24} />
       </button>
     </div>
   );

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import { Icon } from '@cds/icon';
+
+import * as styles from './memo-tab.css';
+
+interface MemoTabProps {
+  memoTitle: string;
+  isSelected: boolean;
+  onSelectTab: () => void;
+  onCloseTab: () => void;
+}
+
+const MemoTab = ({
+  memoTitle,
+  isSelected,
+  onSelectTab,
+  onCloseTab,
+}: MemoTabProps) => {
+  // TODO: Icon 컴포넌트를 className cn 방식으로 -> hover 등을 class로 조정
+  const [isHovered, setIsHovered] = useState(false);
+  const isHoverActive = isHovered && !isSelected;
+  const iconColor = isHoverActive
+    ? 'grey600'
+    : isSelected
+      ? 'blue500'
+      : 'grey500';
+
+  return (
+    <div
+      onClick={onSelectTab}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={styles.container({ isSelected })}
+      role="button"
+    >
+      <div className={styles.memoContainer}>
+        <Icon
+          name="ic_memo"
+          size={32}
+          color={iconColor}
+          className={styles.icon}
+        />
+        <span className={styles.memoTitle({ isSelected })}>{memoTitle}</span>
+      </div>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onCloseTab();
+        }}
+        type="button"
+        className={styles.closeMemo}
+      >
+        <Icon name="ic_delete" size={32} />
+      </button>
+    </div>
+  );
+};
+
+export default MemoTab;

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -30,7 +30,7 @@ const MemoTab = ({
     <div
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      className={styles.container({ isSelected })}
+      className={styles.container({ isSelected, isHoverActive })}
     >
       <button
         type="button"
@@ -44,13 +44,15 @@ const MemoTab = ({
           color={iconColor}
           className={styles.icon}
         />
-        <span className={styles.memoTitle({ isSelected })}>{memoTitle}</span>
+        <span className={styles.memoTitle({ isSelected, isHoverActive })}>
+          {memoTitle}
+        </span>
       </button>
       <button
         onClick={onCloseTab}
         type="button"
         aria-label={`${memoTitle} 탭 닫기`}
-        className={styles.closeTab}
+        className={styles.closeTab({ isHovered })}
       >
         <Icon name="ic_delete" size={24} />
       </button>

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -28,13 +28,16 @@ const MemoTab = ({
 
   return (
     <div
-      onClick={onSelectTab}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className={styles.container({ isSelected })}
-      role="button"
     >
-      <div className={styles.memoContainer}>
+      <button
+        type="button"
+        onClick={onSelectTab}
+        aria-current={isSelected ? 'page' : undefined}
+        className={styles.selectTab}
+      >
         <Icon
           name="ic_memo"
           size={32}
@@ -42,15 +45,12 @@ const MemoTab = ({
           className={styles.icon}
         />
         <span className={styles.memoTitle({ isSelected })}>{memoTitle}</span>
-      </div>
+      </button>
       <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onCloseTab();
-        }}
+        onClick={onCloseTab}
         type="button"
         aria-label={`${memoTitle} 탭 닫기`}
-        className={styles.closeMemo}
+        className={styles.closeTab}
       >
         <Icon name="ic_delete" size={24} />
       </button>

--- a/apps/client/src/shared/components/memo-tab/memo-tab.tsx
+++ b/apps/client/src/shared/components/memo-tab/memo-tab.tsx
@@ -17,7 +17,7 @@ const MemoTab = ({
   onSelectTab,
   onCloseTab,
 }: MemoTabProps) => {
-  // TODO: Icon 컴포넌트를 className cn 방식으로 -> hover 등을 class로 조정
+  // @TODO: Icon 컴포넌트를 className cn 방식으로 -> hover 등을 class로 조정
   const [isHovered, setIsHovered] = useState(false);
   const isHoverActive = isHovered && !isSelected;
   const iconColor = isHoverActive


### PR DESCRIPTION
## 📌 Summary

- #264

메모 탭 목록에서 개별 탭 하나를 표현하는 MemoTab 컴포넌트를 구현했어요.

## 📚 Tasks

- MemoTab 컴포넌트 및 스타일(memo-tab.tsx, memo-tab.css.ts) 신규 작성
- 선택(select) / 닫기(close) 상태를 상위에서 제어할 수 있도록 controlled 컴포넌트로 설계
- hover 시 아이콘·텍스트 색상 및 닫기 버튼 노출 처리
- 텍스트 1줄 고정 + ellipsis 처리

## 🔍 Describe

- `isSelected`는 내부 state가 아닌 prop으로 받아, 여러 MemoTab이 리스트로 렌더될 때 "동시에 하나만 선택"되는 제약을 상위 컴포넌트가 관리하도록 설계했어요.
- `onSelectTab` / `onCloseTab` 콜백은 인자 없는 순수 콜백으로, 어떤 탭인지·다음에 뭘 할지는 모두 사용처(부모)의 책임으로 넘겼어요.
- 닫기(X) 버튼 클릭 시 상위 div의 onClick(select)까지 같이 발동되는 이벤트 버블링 문제를 `e.stopPropagation()`으로 처리했어요.
- Icon의 `color`가 인라인 style로 적용되는 구조라 CSS `:hover`만으로는 아이콘 색을 못 바꿔서, hover/selected 상태를 조합한 `isHoverActive` 변수로 명시적으로 우선순위를 표현하고 JS에서 색을 계산하도록 했습니다.

### 논의점
하나의 컴포넌트 안에 hover의 동작 원천이 2개가 있어요. (CSS :hover, JS isHovered state)
원천이 하나가 아니라면 변경할 때 고려해야 할 인지부하가 생기게 돼요.
"JS 호버를 고칠 때 CSS 호버도 함께 수정되어야 하는가?" 처럼요.

이유는 Icon 컴포넌트의 style 우선순위가 높아 className을 넣어도 적용이 되지 않아요.
회의 때 함께 얘기해보아요!

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->


## 📸 Screenshot

<img width="790" height="113" alt="스크린샷 2026-07-30 152644" src="https://github.com/user-attachments/assets/f9a38aee-7bfb-4e23-ab7e-134b88c4b8e0" />

