### PR TITLE
Feat(root): PR 리뷰어 공정 자동 할당 기능 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @TEAM-CLUSTAR/clustar-client

--- a/.github/reviewer-assignment.json
+++ b/.github/reviewer-assignment.json
@@ -1,0 +1,26 @@
+{
+  "reviewerCount": 1,
+  "lookbackDays": 60,
+  "reviewers": [
+    {
+      "login": "jm8468",
+      "weight": 1,
+      "enabled": true
+    },
+    {
+      "login": "jogpfls",
+      "weight": 1,
+      "enabled": true
+    },
+    {
+      "login": "twossu",
+      "weight": 1,
+      "enabled": true
+    },
+    {
+      "login": "jyeon03",
+      "weight": 1,
+      "enabled": true
+    }
+  ]
+}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,4 +1,4 @@
-name: Auto Assign Author
+name: Auto Assign
 
 on:
   issues:
@@ -7,11 +7,12 @@ on:
     types: [opened, ready_for_review]
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 
 jobs:
-  assign-author:
+  assign:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to issue/PR
@@ -28,3 +29,125 @@ jobs:
               issue_number: context.issue.number,
               assignees: [author]
             });
+
+      - name: Checkout reviewer assignment config
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Assign fair reviewer
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const config = JSON.parse(
+              fs.readFileSync('.github/reviewer-assignment.json', 'utf8')
+            );
+
+            const { owner, repo } = context.repo;
+            const currentPullRequest = context.payload.pull_request;
+            const author = currentPullRequest.user.login;
+            const reviewerCount = config.reviewerCount ?? 1;
+            const lookbackDays = config.lookbackDays ?? 60;
+
+            const candidates = config.reviewers
+              .filter(({ login, enabled = true, weight = 1 }) => {
+                return enabled && weight > 0 && login !== author;
+              })
+              .map(({ login, weight = 1 }) => ({ login, weight }));
+
+            if (candidates.length === 0 || reviewerCount <= 0) {
+              core.info('No eligible reviewer candidates.');
+              return;
+            }
+
+            const since = new Date();
+            since.setDate(since.getDate() - lookbackDays);
+            const sinceDate = since.toISOString().slice(0, 10);
+
+            const candidateLogins = new Set(
+              candidates.map(({ login }) => login)
+            );
+            const reviewCounts = Object.fromEntries(
+              candidates.map(({ login }) => [login, 0])
+            );
+
+            const pullRequests = await github.paginate(
+              github.rest.search.issuesAndPullRequests,
+              {
+                q: `repo:${owner}/${repo} is:pr created:>=${sinceDate}`,
+                per_page: 100,
+              }
+            );
+
+            for (const item of pullRequests) {
+              if (item.number === currentPullRequest.number) continue;
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: item.number,
+              });
+
+              const assignedReviewers = new Set(
+                pullRequest.requested_reviewers
+                  .map(({ login }) => login)
+                  .filter((login) => candidateLogins.has(login))
+              );
+
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                {
+                  owner,
+                  repo,
+                  pull_number: item.number,
+                  per_page: 100,
+                }
+              );
+
+              for (const { user } of reviews) {
+                if (user && candidateLogins.has(user.login)) {
+                  assignedReviewers.add(user.login);
+                }
+              }
+
+              for (const reviewer of assignedReviewers) {
+                reviewCounts[reviewer] += 1;
+              }
+            }
+
+            const alreadyRequested = new Set(
+              currentPullRequest.requested_reviewers.map(({ login }) => login)
+            );
+            const selectedReviewers = candidates
+              .filter(({ login }) => !alreadyRequested.has(login))
+              .map(({ login, weight }) => ({
+                login,
+                score: reviewCounts[login] / weight,
+                count: reviewCounts[login],
+                tieBreaker: Math.random(),
+              }))
+              .sort((a, b) => {
+                return (
+                  a.score - b.score ||
+                  a.count - b.count ||
+                  a.tieBreaker - b.tieBreaker
+                );
+              })
+              .slice(0, reviewerCount)
+              .map(({ login }) => login);
+
+            if (selectedReviewers.length === 0) {
+              core.info('No new reviewers to request.');
+              return;
+            }
+
+            await github.rest.pulls.requestReviewers({
+              owner,
+              repo,
+              pull_number: currentPullRequest.number,
+              reviewers: selectedReviewers,
+            });
+
+            core.info(`Requested reviewers: ${selectedReviewers.join(', ')}`);


### PR DESCRIPTION
## 📌 Summary

> - #295

팀 전체를 리뷰어로 할당하던 방식을 제거하고, 최근 리뷰 갯수를 기준으로 리뷰어 1명을 자동 할당하는 공정 리뷰어 할당 로직을 추가했습니다✌🏻

## 📚 Tasks
- 기존 `CODEOWNERS` 기반 팀 전체 리뷰어 할당 제거
- 리뷰어 자동 할당 설정 파일 추가
- PR 작성자를 제외한 리뷰어 후보군 설정
- 최근 60일 기준 리뷰 부담 계산
- 리뷰 부담이 적은 팀원을 우선 배정하는 알고리즘 구현
- 바쁘거나 부재 중인 팀원의 할당 비중을 조절할 수 있는 `weight`, `enabled` 옵션 추가

## 🔍 Describe

### 1. 기존 팀 전체 리뷰어 할당 제거
> 기존에는 `.github/CODEOWNERS`에 팀 전체가 등록되어 있어 PR마다 팀원 전체가 리뷰어로 할당될 수 있는 구조였습니다.

```txt
* @TEAM-CLUSTAR/clustar-client
```

- 기존 방식은 실제로 리뷰를 담당해야 하는 사람이 명확하지 않기도하고 모든 팀원에게 리뷰 요청이 가면서 리뷰 부담이 분산되기보다 흐려졌다고 판단했습니다!!

- GitHub Repository 설정에서 `Require review from Code Owners` 옵션도 꺼져 있는 상태라, CODEOWNERS 파일은 제거했습니다.

### 2. 리뷰어 설정 파일 추가
> 리뷰어 후보와 할당 기준을 코드가 아닌 설정 파일에서 관리할 수 있도록 `.github/reviewer-assignment.json`을 추가했습니다.

```json
{
  "reviewerCount": 1,
  "lookbackDays": 60,
  "reviewers": [
    {
      "login": "jm8468",
      "weight": 1,
      "enabled": true
    },
    {
      "login": "jogpfls",
      "weight": 1,
      "enabled": true
    },
    {
      "login": "twossu",
      "weight": 1,
      "enabled": true
    },
    {
      "login": "jyeon03",
      "weight": 1,
      "enabled": true
    }
  ]
}
```

- `reviewerCount`: PR당 자동 할당할 리뷰어 수
- `lookbackDays`: 리뷰 부담 계산 기간
- `login`: GitHub 계정명
- `weight`: 리뷰어 할당 가중치
- `enabled`: 리뷰어 후보 포함 여부

### 3. 리뷰 부담 계산 기준
> 리뷰 부담은 **리뷰 코멘트 개수**가 아니라 **리뷰를 맡은 PR 개수** 기준으로 계산했습니다.
최근 60일 동안 각 PR에서 아래 조건 중 하나라도 해당하면 해당 리뷰어의 리뷰 담당 횟수를 1건으로 계산합니다.

- requested reviewer로 지정된 경우
- 실제 review를 남긴 경우

-> 코멘트 개수를 기준으로 계산하면 꼼꼼하게 리뷰를 많이 남긴 사람이 오히려 더 불리해질 수 있어서, PR 단위로 계산하는 방식이 더 공정하다고 판단했습니다.

### 4. 리뷰어 선택 방식
- PR 작성자는 리뷰어 후보에서 제외합니다.
- 후보별로 최근 리뷰 부담과 `weight`를 기준으로 점수를 계산하고, 점수가 낮은 사람을 우선 선택합니다.

```txt
score = 최근 리뷰 PR 수 / weight
```

- 예를 들어 특정 팀원이 바쁜 기간이라면 `weight`를 낮춰서 덜 배정되게 할 수 있습니다.

```json
{
  "login": "twossu",
  "weight": 0.5,
  "enabled": true
}
```

- 아예 리뷰어 후보에서 제외해야 하는 경우에는 `enabled`를 `false`로 설정하면 됩니다.

```json
{
  "login": "twossu",
  "weight": 1,
  "enabled": false
}
```

### 5. 기존 작성자 assignee 자동 할당 유지
> 기존 workflow에서 issue/PR 작성자를 assignee로 지정하던 동작은 유지했습니다.

```txt
issue/PR 작성자 → assignee 자동 지정
PR → 공정 알고리즘 기반 reviewer 자동 지정
```

## 👀 To Reviewer
- lookbackDays를 60일로 설정하는 게 적당할까요??