### PR TITLE
Feat(client): TagSelectField 컴포넌트 구현

### DIFF
--- a/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.css.ts
+++ b/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.css.ts
@@ -1,0 +1,39 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@cds/ui';
+
+export const field = recipe({
+  base: {
+    display: 'flex',
+    padding: '0.8rem',
+    borderRadius: '8px',
+    backgroundColor: themeVars.color.grey50,
+    border: '1px solid transparent',
+  },
+  variants: {
+    isActive: {
+      true: {
+        borderColor: themeVars.color.blue500,
+      },
+      false: {
+        borderColor: themeVars.color.grey300,
+      },
+    },
+  },
+});
+
+export const placeholder = style({
+  ...themeVars.fontStyles.body_m_16,
+  color: themeVars.color.grey500,
+});
+
+export const tagList = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.8rem',
+  flexWrap: 'nowrap',
+  overflowX: 'auto',
+  flex: 1,
+  minWidth: 0,
+});

--- a/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
+++ b/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
@@ -20,8 +20,8 @@ const TagSelectField = ({ selectedTags, onRemoveTag }: TagSelectFieldProps) => {
             <Tag
               key={tagId}
               size="lg"
-              color={color ?? ''}
-              text={name ?? ''}
+              color={color}
+              text={name}
               action="remove"
               onRemove={() => onRemoveTag(tagId)}
             />

--- a/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
+++ b/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
@@ -5,18 +5,18 @@ import { TagNode } from '@shared/apis/tag/type';
 import * as styles from './tag-select-field.css';
 
 interface TagSelectFieldProps {
-  tags: TagNode[];
+  selectedTags: TagNode[];
   onRemoveTag: (tagId: number) => void;
 }
 
-const TagSelectField = ({ tags, onRemoveTag }: TagSelectFieldProps) => {
-  const hasTags = tags.length > 0;
+const TagSelectField = ({ selectedTags, onRemoveTag }: TagSelectFieldProps) => {
+  const hasTags = selectedTags.length > 0;
 
   return (
     <div className={styles.field({ isActive: hasTags })}>
       {hasTags ? (
         <div className={styles.tagList}>
-          {tags.map(({ tagId, name, color }) => (
+          {selectedTags.map(({ tagId, name, color }) => (
             <Tag
               key={tagId}
               size="lg"

--- a/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
+++ b/apps/client/src/features/filter-modal/tag-select-field/tag-select-field.tsx
@@ -1,0 +1,39 @@
+import { Tag } from '@cds/ui';
+
+import { TagNode } from '@shared/apis/tag/type';
+
+import * as styles from './tag-select-field.css';
+
+interface TagSelectFieldProps {
+  tags: TagNode[];
+  onRemoveTag: (tagId: number) => void;
+}
+
+const TagSelectField = ({ tags, onRemoveTag }: TagSelectFieldProps) => {
+  const hasTags = tags.length > 0;
+
+  return (
+    <div className={styles.field({ isActive: hasTags })}>
+      {hasTags ? (
+        <div className={styles.tagList}>
+          {tags.map(({ tagId, name, color }) => (
+            <Tag
+              key={tagId}
+              size="lg"
+              color={color ?? ''}
+              text={name ?? ''}
+              action="remove"
+              onRemove={() => onRemoveTag(tagId)}
+            />
+          ))}
+        </div>
+      ) : (
+        <span className={styles.placeholder}>
+          원하시는 태그를 선택해주세요.
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default TagSelectField;

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.css.ts
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.css.ts
@@ -6,9 +6,7 @@ import { themeVars } from '@cds/ui';
 export const field = recipe({
   base: {
     display: 'flex',
-    alignItems: 'center',
     gap: '0.4rem',
-    width: '100%',
     padding: '0.8rem',
     borderRadius: '8px',
     border: '0.15rem solid transparent',

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.css.ts
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.css.ts
@@ -1,0 +1,50 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@cds/ui';
+
+export const field = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.4rem',
+    width: '100%',
+    padding: '0.8rem',
+    borderRadius: '8px',
+    border: '0.15rem solid transparent',
+  },
+  variants: {
+    isActive: {
+      true: {
+        borderColor: themeVars.color.blue500,
+        backgroundColor: themeVars.color.grey50,
+      },
+      false: {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+});
+
+export const tagList = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+  flexWrap: 'nowrap',
+  overflowX: 'auto',
+  flex: 1,
+  minWidth: 0,
+});
+
+export const input = style({
+  ...themeVars.fontStyles.title_m_18,
+  flex: 1,
+  minWidth: 0,
+  color: themeVars.color.grey800,
+  backgroundColor: 'transparent',
+  outline: 'none',
+
+  '::placeholder': {
+    color: themeVars.color.grey600,
+  },
+});

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEvent, useRef } from 'react';
+import { KeyboardEvent } from 'react';
 
 import { Icon } from '@cds/icon';
 import { Tag } from '@cds/ui';
@@ -10,33 +10,24 @@ import * as styles from './tag-input-field.css';
 interface TagInputFieldProps {
   selectedTags: TagNode[];
   onRemoveTag: (tagId: number) => void;
-  value: string;
   isOpen: boolean;
-  onChange: (value: string) => void;
   onFocus: () => void;
-  onEnter?: () => boolean;
+  onEnter?: (value: string) => boolean;
 }
 
 const TagInputField = ({
   selectedTags,
   onRemoveTag,
-  value,
   isOpen,
-  onChange,
   onFocus,
   onEnter,
 }: TagInputFieldProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange(event.target.value);
-  };
-
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
-    if (!onEnter?.()) return;
+    if (!onEnter?.(event.currentTarget.value)) return;
 
-    inputRef.current?.blur();
+    event.currentTarget.value = '';
+    event.currentTarget.blur();
   };
 
   return (
@@ -58,11 +49,8 @@ const TagInputField = ({
           ),
         )}
         <input
-          ref={inputRef}
           className={styles.input}
-          value={value}
           placeholder={selectedTags.length ? '' : '태그 선택'}
-          onChange={handleChange}
           onFocus={onFocus}
           onKeyDown={handleKeyDown}
         />

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -48,13 +48,13 @@ const TagInputField = ({
             <Tag
               key={tagId}
               size="lg"
-              color={color ?? ''}
-              text={name ?? ''}
+              color={color}
+              text={name}
               action="remove"
               onRemove={() => onRemoveTag(tagId)}
             />
           ) : (
-            <Tag key={tagId} size="lg" color={color ?? ''} text={name ?? ''} />
+            <Tag key={tagId} size="lg" color={color} text={name} />
           ),
         )}
         <input

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -12,7 +12,6 @@ interface TagInputFieldProps {
   onRemoveTag: (tagId: number) => void;
   value: string;
   isOpen: boolean;
-  placeholder: string;
   onChange: (value: string) => void;
   onFocus: () => void;
   onEnter?: () => boolean;
@@ -23,7 +22,6 @@ const TagInputField = ({
   onRemoveTag,
   value,
   isOpen,
-  placeholder,
   onChange,
   onFocus,
   onEnter,
@@ -45,21 +43,25 @@ const TagInputField = ({
     <div className={styles.field({ isActive: isOpen })}>
       <Icon name="ic_tag" size={32} color={isOpen ? 'blue500' : 'grey600'} />
       <div className={styles.tagList}>
-        {selectedTags.map(({ tagId, name, color }) => (
-          <Tag
-            key={tagId}
-            size="lg"
-            color={color ?? ''}
-            text={name ?? ''}
-            action="remove"
-            onRemove={() => onRemoveTag(tagId)}
-          />
-        ))}
+        {selectedTags.map(({ tagId, name, color }) =>
+          isOpen ? (
+            <Tag
+              key={tagId}
+              size="lg"
+              color={color ?? ''}
+              text={name ?? ''}
+              action="remove"
+              onRemove={() => onRemoveTag(tagId)}
+            />
+          ) : (
+            <Tag key={tagId} size="lg" color={color ?? ''} text={name ?? ''} />
+          ),
+        )}
         <input
           ref={inputRef}
           className={styles.input}
           value={value}
-          placeholder={selectedTags.length ? '' : placeholder}
+          placeholder={selectedTags.length ? '' : '태그 선택'}
           onChange={handleChange}
           onFocus={onFocus}
           onKeyDown={handleKeyDown}

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -1,0 +1,72 @@
+import { ChangeEvent, KeyboardEvent, useRef } from 'react';
+
+import { Icon } from '@cds/icon';
+import { Tag } from '@cds/ui';
+
+import { TagNode } from '@shared/apis/tag/type';
+
+import * as styles from './tag-input-field.css';
+
+interface TagInputFieldProps {
+  selectedTags: TagNode[];
+  onRemoveTag: (tagId: number) => void;
+  value: string;
+  isOpen: boolean;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onFocus: () => void;
+  onEnter?: () => boolean;
+}
+
+const TagInputField = ({
+  selectedTags,
+  onRemoveTag,
+  value,
+  isOpen,
+  placeholder,
+  onChange,
+  onFocus,
+  onEnter,
+}: TagInputFieldProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
+    if (!onEnter?.()) return;
+
+    inputRef.current?.blur();
+  };
+
+  return (
+    <div className={styles.field({ isActive: isOpen })}>
+      <Icon name="ic_tag" size={32} color={isOpen ? 'blue500' : 'grey600'} />
+      <div className={styles.tagList}>
+        {selectedTags.map(({ tagId, name, color }) => (
+          <Tag
+            key={tagId}
+            size="lg"
+            color={color ?? ''}
+            text={name ?? ''}
+            action="remove"
+            onRemove={() => onRemoveTag(tagId)}
+          />
+        ))}
+        <input
+          ref={inputRef}
+          className={styles.input}
+          value={value}
+          placeholder={selectedTags.length ? '' : placeholder}
+          onChange={handleChange}
+          onFocus={onFocus}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TagInputField;

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -50,7 +50,7 @@ const TagInputField = ({
         )}
         <input
           className={styles.input}
-          placeholder={selectedTags.length ? '' : '태그 선택'}
+          placeholder={selectedTags.length === 0 ? '태그 선택' : ''}
           onFocus={onFocus}
           onKeyDown={handleKeyDown}
         />

--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -24,7 +24,9 @@ const TagInputField = ({
 }: TagInputFieldProps) => {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
-    if (!onEnter?.(event.currentTarget.value)) return;
+
+    const isTagAdded = onEnter?.(event.currentTarget.value);
+    if (!isTagAdded) return;
 
     event.currentTarget.value = '';
     event.currentTarget.blur();


### PR DESCRIPTION
## 📌 Summary

> - #294

FilterModal에서 사용되는 `TagSelectField`와 TagPopover에서 사용되는 `TagInputField` 컴포넌트를 구현했습니다.

## 📚 Tasks

- `TagSelectField` 컴포넌트 구현
- `TagInputField` 컴포넌트 구현

## 🔍 Describe

### Stack PR 구조
> `feat/parent-tag-list-component/#291` 브랜치 위에서 작업한 Stack PR입니다.

```txt
feat/tag-tree-select-component/#286
└── feat/parent-tag-list-component/#291
    └── feat/tag-select-field-component/#294 (현재 PR)
```

### `TagSelectField` vs `TagInputField`

둘 다 선택된 태그를 칩으로 보여주고 제거하는 기능과 디자인이 비슷하지만 들여다보면 기능이 달라서 컴포넌트를 따로 제작했습니다.

- `TagSelectField`: FilterModal에서 이미 선택된 태그를 보여주고 제거만 하는 필드라 입력 기능이 없습니다.
- `TagInputField`: TagPopover에서 메모 작성 시 태그를 직접 입력해서 짓는 필드라 텍스트 입력, Enter 확정, 포커스 시 팝오버를 여는 기능이 추가로 필요합니다.

### TagInputField에서 `onEnter?: () => boolean`를 boolean으로 설계한 이유

`TagInputField`는 Enter로 태그를 "확정"할 때 실제로 어떤 처리가 일어나는지(중복 태그 체크, 빈 값 체크, 새 태그 생성/선택 등)는 알지 못합니다. 이 처리는 이 필드를 사용하는 부모(TagPopover 쪽) 로직의 책임이기 때문에 `onEnter` 콜백으로 위임하고 **그 처리가 성공했는지 여부를 boolean으로 돌려받도록** 설계했습니다.

```ts
const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
  if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
  if (!onEnter?.()) return;

  inputRef.current?.blur();
};
```

- `onEnter()`가 `true`를 반환 → 확정 처리가 정상적으로 끝났다는 뜻이므로 `input`을 blur시켜 입력을 마무리합니다.
- `onEnter()`가 `false`를 반환 → 확정 처리가 실패(예: 중복 태그, 유효하지 않은 입력 등)했다는 뜻이므로 blur하지 않고 입력 포커스를 유지해 사용자가 다시 고쳐 입력할 수 있게 합니다.

즉 반환값은 "확정 성공/실패" 신호로만 쓰이고 `TagInputField`는 실제 확정 로직에는 관여하지 않은 채 그 결과에 따라 **blur 여부(=입력을 닫을지 계속 열어둘지)만 결정**합니다. `onEnter: () => void`로 뒀다면 부모가 실패를 컴포넌트에 알릴 방법이 없어서 실패했는데도 input이 닫혀버리는 문제가 생겼을 것입니다. boolean 반환으로 부모의 처리 결과에 맞춰 자식의 UI 상태를 제어할 수 있게 한 게 핵심입니다.

## 👀 To Reviewer

필드 컴포넌트 네이밍 추천해주세요/.//
filtermodal에서 사용되는 필드는 태그를 선택하는 기능밖에 없기에 select Field가 어울려서 딱이지만,
TagPopover에서 사용되는 필드는 태그 선택, 태그 검색 및 추가 기능 이 있는데 그렇다면 TagSearchField는 너무 태그를 검색하는 컴포넌트 일것만 같고 TagInputField 또한 검색, 입력을 할것만 같은데 그나마 이게 직관적인것같아서 우선 했는데 매우 만족까지는 아닙니다...
아니묜 tag-popover-field 이런 네이밍도 있지만 그렇다면 필터모달에서 사용되는 필드컴포넌트도 tag-filter-field로 바뀌는것이 통일성? 이 좋다고 생각했사옵니다...(그치만 TagSelectField를 잃고 싶지않아요)

## 📸 Screenshot
TagSelectField

https://github.com/user-attachments/assets/c3bf77a7-e6a2-4319-b030-e3d07f9b5978


TagInputField ( 아 검색도되는데 영상을 찍지 못하였군요...)

https://github.com/user-attachments/assets/2f01caab-6df2-455f-b5b9-875d1e00c422
