### PR TITLE
Feat(client): TagPopover 컴포넌트 리디자인 반영

### DIFF
--- a/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
+++ b/apps/client/src/features/tag-popover/tag-input-field/tag-input-field.tsx
@@ -3,17 +3,9 @@ import { KeyboardEvent } from 'react';
 import { Icon } from '@cds/icon';
 import { Tag } from '@cds/ui';
 
-import { TagNode } from '@shared/apis/tag/type';
+import { TagInputFieldProps } from '../type';
 
 import * as styles from './tag-input-field.css';
-
-interface TagInputFieldProps {
-  selectedTags: TagNode[];
-  onRemoveTag: (tagId: number) => void;
-  isOpen: boolean;
-  onFocus: () => void;
-  onEnter?: (value: string) => boolean;
-}
 
 const TagInputField = ({
   selectedTags,

--- a/apps/client/src/features/tag-popover/tag-popover.css.ts
+++ b/apps/client/src/features/tag-popover/tag-popover.css.ts
@@ -1,0 +1,58 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@cds/ui';
+
+export const container = style({
+  position: 'relative',
+  width: '100%',
+});
+
+export const panel = style({
+  position: 'absolute',
+  top: 'calc(100% + 0.4rem)',
+  width: '100%',
+  maxHeight: '31.2rem',
+  padding: '1.4rem',
+  backgroundColor: themeVars.color.white,
+  border: `1px solid ${themeVars.color.grey300}`,
+  borderRadius: '8px',
+  boxShadow: '0 0 16px 4px rgba(0, 0, 0, 0.03)',
+  overflow: 'hidden',
+});
+
+export const label = style({
+  ...themeVars.fontStyles.label_m_12,
+  color: themeVars.color.grey500,
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  height: '25.6rem',
+  gap: '1rem',
+  marginTop: '1.2rem',
+});
+
+export const treeContainer = style({
+  flex: 1,
+  overflowY: 'auto',
+});
+
+export const createFieldButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+  width: '100%',
+  marginTop: '1rem',
+  padding: '0 0.8rem',
+  height: '3.6rem',
+  backgroundColor: themeVars.color.grey100,
+  borderRadius: '8px',
+});
+
+export const createText = style({
+  ...themeVars.fontStyles.body_m_16,
+  color: themeVars.color.grey800,
+  whiteSpace: 'nowrap',
+  overflowX: 'auto',
+  minWidth: 0,
+});

--- a/apps/client/src/features/tag-popover/tag-popover.tsx
+++ b/apps/client/src/features/tag-popover/tag-popover.tsx
@@ -1,0 +1,88 @@
+import { Icon } from '@cds/icon';
+
+import { TagNode } from '@shared/apis/tag/type';
+import ParentTagList from '@shared/components/parent-tag-list/parent-tag-list';
+import TagCheckTree from '@shared/components/tag-check-tree/tag-check-tree';
+import { TreeNode } from '@shared/utils/build-tree';
+
+import TagInputField from './tag-input-field/tag-input-field';
+import { TagInputFieldProps } from './type';
+
+import * as styles from './tag-popover.css';
+
+type TagPopoverPanelProps =
+  | {
+      mode: 'browse';
+      selectedCount: number;
+      parentTags: TagNode[];
+      selectedParentId: number;
+      onSelectParent: (tagId: number) => void;
+      tagTree: TreeNode<TagNode>;
+      selectedIds: number[];
+      onToggleTag: (tagId: number) => void;
+    }
+  | {
+      mode: 'create';
+      newTagName: string;
+      onCreate: () => void;
+    };
+
+type TagPopoverProps = TagInputFieldProps & TagPopoverPanelProps;
+
+const TagPopover = (props: TagPopoverProps) => {
+  return (
+    <div className={styles.container}>
+      <TagInputField
+        selectedTags={props.selectedTags}
+        onRemoveTag={props.onRemoveTag}
+        isOpen={props.isOpen}
+        onFocus={props.onFocus}
+        onEnter={props.onEnter}
+      />
+
+      {props.isOpen && (
+        <div className={styles.panel}>
+          {props.mode === 'browse' ? (
+            <>
+              <span className={styles.label}>
+                태그 선택({props.selectedCount}개)
+              </span>
+
+              <div className={styles.contentContainer}>
+                <ParentTagList
+                  tags={props.parentTags}
+                  selectedTagId={props.selectedParentId}
+                  onSelect={props.onSelectParent}
+                />
+                <div className={styles.treeContainer}>
+                  <TagCheckTree
+                    tag={props.tagTree}
+                    selectedIds={props.selectedIds}
+                    onToggle={props.onToggleTag}
+                  />
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <span className={styles.label}>태그 생성</span>
+
+              <button
+                type="button"
+                className={styles.createFieldButton}
+                onClick={props.onCreate}
+              >
+                <Icon name="ic_plus" size={20} color="grey600" />
+                <span className={styles.createText}>
+                  {props.newTagName || '새로운 태그명'}
+                </span>
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TagPopover;

--- a/apps/client/src/features/tag-popover/tag-popover.tsx
+++ b/apps/client/src/features/tag-popover/tag-popover.tsx
@@ -13,7 +13,6 @@ import * as styles from './tag-popover.css';
 type TagPopoverPanelProps =
   | {
       mode: 'browse';
-      selectedCount: number;
       parentTags: TagNode[];
       selectedParentId: number;
       onSelectParent: (tagId: number) => void;
@@ -45,7 +44,7 @@ const TagPopover = (props: TagPopoverProps) => {
           {props.mode === 'browse' ? (
             <>
               <span className={styles.label}>
-                태그 선택({props.selectedCount}개)
+                태그 선택({props.selectedIds.length}개)
               </span>
 
               <div className={styles.contentContainer}>

--- a/apps/client/src/features/tag-popover/tag-popover.tsx
+++ b/apps/client/src/features/tag-popover/tag-popover.tsx
@@ -1,3 +1,5 @@
+import { FocusEvent } from 'react';
+
 import { Icon } from '@cds/icon';
 
 import { TagNode } from '@shared/apis/tag/type';
@@ -26,11 +28,25 @@ type TagPopoverPanelProps =
       onCreate: () => void;
     };
 
-type TagPopoverProps = TagInputFieldProps & TagPopoverPanelProps;
+type TagPopoverProps = TagInputFieldProps &
+  TagPopoverPanelProps & {
+    onClose: () => void;
+  };
 
 const TagPopover = (props: TagPopoverProps) => {
+  const handleBlur = ({
+    currentTarget,
+    relatedTarget,
+  }: FocusEvent<HTMLElement>) => {
+    if (
+      !(relatedTarget instanceof Node && currentTarget.contains(relatedTarget))
+    ) {
+      props.onClose();
+    }
+  };
+
   return (
-    <div className={styles.container}>
+    <div className={styles.container} onBlur={handleBlur} tabIndex={-1}>
       <TagInputField
         selectedTags={props.selectedTags}
         onRemoveTag={props.onRemoveTag}

--- a/apps/client/src/features/tag-popover/type.ts
+++ b/apps/client/src/features/tag-popover/type.ts
@@ -1,0 +1,9 @@
+import { TagNode } from '@shared/apis/tag/type';
+
+export interface TagInputFieldProps {
+  selectedTags: TagNode[];
+  onRemoveTag: (tagId: number) => void;
+  isOpen: boolean;
+  onFocus: () => void;
+  onEnter?: (value: string) => boolean;
+}


### PR DESCRIPTION
## 📌 Summary

> - #299


메모 작성 화면에서 태그를 선택/생성할 때 쓰는 `TagPopover` 컴포넌트를 구현했어요. 기존에 만들어둔 `TagInputField`, `ParentTagList`, `TagTreeSelect`를 조합해서 완성했습니다.

## 📚 Tasks

- `TagInputFieldProps` 인터페이스를 `tag-input-field.tsx`에서 `tag-popover/type.ts`로 분리
- `TagPopover` 컴포넌트 UI 구현 (태그 선택 / 태그 생성 두 모드)

## 🔍 Describe

### TagInputFieldProps 분리

`TagPopover`에서도 같은 props 타입이 필요해서 `tag-input-field.tsx`에 있던 `TagInputFieldProps`를 `tag-popover/type.ts`로 옮기고 양쪽에서 가져다 쓰도록 했습니다.

### TagPopover의 두 모드 (browse / create)

팝오버 하나에서 "기존 태그 선택" 화면과 "새 태그 생성" 화면을 둘 다 보여줘야 해서 `mode` 값으로 나뉘는 discriminated union으로 props 타입을 설계했어요.

```ts
type TagPopoverPanelProps =
  | { mode: 'browse'; parentTags: TagNode[]; tagTree: TreeNode<TagNode>; ... }
  | { mode: 'create'; newTagName: string; onCreate: () => void };
```

- `browse` 모드: 왼쪽에 `ParentTagList`(부모 태그 한 줄 목록), 오른쪽에 `TagTreeSelect`(선택된 부모의 자식 태그 트리)를 배치
- `create` 모드: 새 태그명을 보여주는 생성 버튼만 노출

모드별 union으로 나눠서 예를 들어 `create` 모드인데 `tagTree`를 안 넘기는 실수를 타입 단계에서 막을 수 있게 했습니다.(like 태그컴포넌트)


## 👀 To Reviewer
사용되는 곳에서 popover가 한번만 쓰이기에 z-index를 넣지않았어요 ㅎㅎ,,,




## 📸 Screenshot
 

https://github.com/user-attachments/assets/f875b5e2-c3e9-43d6-90a4-c25c4c3f93b7

