### PR TITLE
Feat(client): FilterModal 컴포넌트 구현

### DIFF
--- a/apps/client/src/features/filter-modal/filter-modal.css.ts
+++ b/apps/client/src/features/filter-modal/filter-modal.css.ts
@@ -56,34 +56,3 @@ export const footer = style({
   justifyContent: 'flex-end',
   paddingTop: '0.8rem',
 });
-
-/** TODO 임시 버튼 공통 버튼 수정후 교체하겠습니다. */
-export const cancelButton = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '12rem',
-  height: '3.6rem',
-  border: `1px solid ${themeVars.color.grey400}`,
-  borderRadius: '8px',
-  backgroundColor: themeVars.color.white,
-  color: themeVars.color.grey700,
-  ...themeVars.fontStyles.body_m_16,
-});
-
-export const applyButton = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '12rem',
-  height: '3.6rem',
-  borderRadius: '8px',
-  color: themeVars.color.white,
-  backgroundColor: themeVars.color.blue500,
-  ...themeVars.fontStyles.body_m_16,
-  selectors: {
-    '&:hover': {
-      backgroundColor: themeVars.color.blue700,
-    },
-  },
-});

--- a/apps/client/src/features/filter-modal/filter-modal.css.ts
+++ b/apps/client/src/features/filter-modal/filter-modal.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@cds/ui';
 
@@ -72,31 +71,19 @@ export const cancelButton = style({
   ...themeVars.fontStyles.body_m_16,
 });
 
-export const applyButton = recipe({
-  base: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '12rem',
-    height: '3.6rem',
-    borderRadius: '8px',
-    color: themeVars.color.white,
-    ...themeVars.fontStyles.body_m_16,
-  },
-  variants: {
-    disabled: {
-      true: {
-        backgroundColor: themeVars.color.grey500,
-        cursor: 'not-allowed',
-      },
-      false: {
-        backgroundColor: themeVars.color.blue500,
-        selectors: {
-          '&:hover': {
-            backgroundColor: themeVars.color.blue700,
-          },
-        },
-      },
+export const applyButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '12rem',
+  height: '3.6rem',
+  borderRadius: '8px',
+  color: themeVars.color.white,
+  backgroundColor: themeVars.color.blue500,
+  ...themeVars.fontStyles.body_m_16,
+  selectors: {
+    '&:hover': {
+      backgroundColor: themeVars.color.blue700,
     },
   },
 });

--- a/apps/client/src/features/filter-modal/filter-modal.css.ts
+++ b/apps/client/src/features/filter-modal/filter-modal.css.ts
@@ -1,0 +1,102 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@cds/ui';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.6rem',
+  width: '82rem',
+  height: '62rem',
+  padding: '2rem 1.8rem',
+  border: `1px solid ${themeVars.color.grey400}`,
+  boxShadow: '0px 0px 24px 8px rgba(0, 0, 0, 0.03)',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  paddingBottom: '0.8rem',
+  borderBottom: `1px solid ${themeVars.color.grey200}`,
+});
+
+export const headerTitle = style({
+  ...themeVars.fontStyles.body_m_14,
+  color: themeVars.color.grey600,
+});
+
+export const body = style({
+  display: 'flex',
+  gap: '1.2rem',
+  flex: 1,
+});
+
+export const panel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+});
+
+export const selectedLabel = style({
+  margin: '1.6rem 0 0.8rem 0',
+  ...themeVars.fontStyles.label_m_12,
+  color: themeVars.color.grey600,
+});
+
+export const treeScroll = style({
+  flex: 1,
+  minHeight: 0,
+  overflowY: 'auto',
+});
+
+export const footer = style({
+  display: 'flex',
+  gap: '0.8rem',
+  justifyContent: 'flex-end',
+  paddingTop: '0.8rem',
+});
+
+/** TODO 임시 버튼 공통 버튼 수정후 교체하겠습니다. */
+export const cancelButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '12rem',
+  height: '3.6rem',
+  border: `1px solid ${themeVars.color.grey400}`,
+  borderRadius: '8px',
+  backgroundColor: themeVars.color.white,
+  color: themeVars.color.grey700,
+  ...themeVars.fontStyles.body_m_16,
+});
+
+export const applyButton = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '12rem',
+    height: '3.6rem',
+    borderRadius: '8px',
+    color: themeVars.color.white,
+    ...themeVars.fontStyles.body_m_16,
+  },
+  variants: {
+    disabled: {
+      true: {
+        backgroundColor: themeVars.color.grey500,
+        cursor: 'not-allowed',
+      },
+      false: {
+        backgroundColor: themeVars.color.blue500,
+        selectors: {
+          '&:hover': {
+            backgroundColor: themeVars.color.blue700,
+          },
+        },
+      },
+    },
+  },
+});

--- a/apps/client/src/features/filter-modal/filter-modal.css.ts
+++ b/apps/client/src/features/filter-modal/filter-modal.css.ts
@@ -32,6 +32,12 @@ export const body = style({
   flex: 1,
 });
 
+export const emptyBody = style({
+  display: 'flex',
+  justifyContent: 'center',
+  marginTop: '9.6rem',
+});
+
 export const panel = style({
   display: 'flex',
   flexDirection: 'column',

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -99,7 +99,7 @@ const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
                   </Modal.Close>
                   <button
                     type="button"
-                    className={styles.applyButton({ disabled: false })}
+                    className={styles.applyButton}
                     onClick={handleApply}
                   >
                     적용하기

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from 'react';
+
+import { Icon } from '@cds/icon';
+import { Modal } from '@cds/ui';
+
+import { useGetTag } from '@shared/apis/tag/queries';
+import ParentTagList from '@shared/components/parent-tag-list/parent-tag-list';
+import TagCheckTree from '@shared/components/tag-check-tree/tag-check-tree';
+import { flattenTree } from '@shared/utils/build-tree';
+
+import TagSelectField from './tag-select-field/tag-select-field';
+
+import * as styles from './filter-modal.css';
+
+interface FilterModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApply: (tagIds: number[]) => void;
+}
+
+const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
+  const { data: roots = [] } = useGetTag();
+  const [activeRootId, setActiveRootId] = useState<number>();
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+  const activeRoot =
+    roots.find((root) => root.tagId === activeRootId) ?? roots[0];
+  const flatTags = useMemo(() => flattenTree(roots), [roots]);
+  const selectedTags = flatTags.filter((tag) =>
+    selectedIds.includes(tag.tagId),
+  );
+
+  const handleToggle = (tagId: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(tagId)
+        ? prev.filter((id) => id !== tagId)
+        : [...prev, tagId],
+    );
+  };
+
+  const handleApply = () => {
+    onApply(selectedIds);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <Modal.Content ariaLabel="태그 필터링">
+        <div className={styles.container}>
+          <div className={styles.header}>
+            <p className={styles.headerTitle}>태그 필터링</p>
+            <Modal.Close>
+              <button type="button" aria-label="닫기">
+                <Icon name="ic_delete" size={24} color="grey700" />
+              </button>
+            </Modal.Close>
+          </div>
+
+          {roots.length ? (
+            <div className={styles.body}>
+              <ParentTagList
+                tags={roots}
+                selectedTagId={activeRoot?.tagId ?? 0}
+                onSelect={setActiveRootId}
+              />
+
+              <div className={styles.panel}>
+                <TagSelectField
+                  selectedTags={selectedTags}
+                  onRemoveTag={handleToggle}
+                />
+
+                <p className={styles.selectedLabel}>
+                  {`선택된 태그(${selectedIds.length}개)`}
+                </p>
+                {activeRoot && (
+                  <div className={styles.treeScroll}>
+                    <TagCheckTree
+                      tag={activeRoot}
+                      selectedIds={selectedIds}
+                      onToggle={handleToggle}
+                    />
+                  </div>
+                )}
+
+                <div className={styles.footer}>
+                  {/** TODO 임시 버튼 공통 버튼 수정후 교체하겠습니다. */}
+                  <Modal.Close>
+                    <button type="button" className={styles.cancelButton}>
+                      취소
+                    </button>
+                  </Modal.Close>
+                  <button
+                    type="button"
+                    className={styles.applyButton({
+                      disabled: selectedIds.length === 0,
+                    })}
+                    disabled={selectedIds.length === 0}
+                    onClick={handleApply}
+                  >
+                    적용하기
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            // TODO: 빈 상태 UI 추후 작업
+            <p>생성된 태그가 없습니다.</p>
+          )}
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+export default FilterModal;

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -14,15 +14,26 @@ import * as styles from './filter-modal.css';
 
 interface FilterModalProps {
   open: boolean;
+  selectedTagIds: number[];
   onOpenChange: (open: boolean) => void;
   onApply: (tagIds: number[]) => void;
 }
 
-const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
+const FilterModal = ({
+  open,
+  selectedTagIds,
+  onOpenChange,
+  onApply,
+}: FilterModalProps) => {
   const { data: roots = [] } = useGetTag();
   const [activeRootId, setActiveRootId] = useState<number>();
-  const [appliedIds, setAppliedIds] = useState<number[]>([]);
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>(selectedTagIds);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setSelectedIds(selectedTagIds);
+  }
 
   const activeRoot =
     roots.find((root) => root.tagId === activeRootId) ?? roots[0];
@@ -40,18 +51,12 @@ const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
   };
 
   const handleApply = () => {
-    setAppliedIds(selectedIds);
     onApply(selectedIds);
     onOpenChange(false);
   };
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) setSelectedIds(appliedIds);
-    onOpenChange(nextOpen);
-  };
-
   return (
-    <Modal open={open} onOpenChange={handleOpenChange}>
+    <Modal open={open} onOpenChange={onOpenChange}>
       <Modal.Content ariaLabel="태그 필터링">
         <div className={styles.container}>
           <div className={styles.header}>

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -27,9 +27,7 @@ const FilterModal = ({
   onOpenChange,
   onApply,
 }: FilterModalProps) => {
-  // TODO: 빈 상태 테스트용 임시 강제 빈 배열, 테스트 후 원복 필요
-  useGetTag();
-  const roots: ReturnType<typeof useGetTag>['data'] = [];
+  const { data: roots = [] } = useGetTag();
   const [activeRootId, setActiveRootId] = useState<number>();
   const [selectedIds, setSelectedIds] = useState<number[]>(selectedTagIds);
   const [prevOpen, setPrevOpen] = useState(open);

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -4,6 +4,8 @@ import { Icon } from '@cds/icon';
 import { Button, Modal } from '@cds/ui';
 
 import { useGetTag } from '@shared/apis/tag/queries';
+import tagImage from '@shared/assets/images/empty-state/tag_image.svg';
+import EmptyState from '@shared/components/empty-state/empty-state';
 import ParentTagList from '@shared/components/parent-tag-list/parent-tag-list';
 import TagCheckTree from '@shared/components/tag-check-tree/tag-check-tree';
 import { flattenTree } from '@shared/utils/build-tree';
@@ -25,7 +27,9 @@ const FilterModal = ({
   onOpenChange,
   onApply,
 }: FilterModalProps) => {
-  const { data: roots = [] } = useGetTag();
+  // TODO: 빈 상태 테스트용 임시 강제 빈 배열, 테스트 후 원복 필요
+  useGetTag();
+  const roots: ReturnType<typeof useGetTag>['data'] = [];
   const [activeRootId, setActiveRootId] = useState<number>();
   const [selectedIds, setSelectedIds] = useState<number[]>(selectedTagIds);
   const [prevOpen, setPrevOpen] = useState(open);
@@ -108,8 +112,13 @@ const FilterModal = ({
               </div>
             </div>
           ) : (
-            // TODO: 빈 상태 UI 추후 작업
-            <p>생성된 태그가 없습니다.</p>
+            <div className={styles.emptyBody}>
+              <EmptyState
+                imageSrc={tagImage}
+                title="생성된 태그가 없습니다."
+                description="새 메모 창에 들어가서 새로운 태그를 생성해보세요."
+              />
+            </div>
           )}
         </div>
       </Modal.Content>

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -1,14 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { Icon } from '@cds/icon';
 import { Button, Modal } from '@cds/ui';
 
-import { useGetTag } from '@shared/apis/tag/queries';
+import { useFlatTags, useGetTag } from '@shared/apis/tag/queries';
 import tagImage from '@shared/assets/images/empty-state/tag_image.svg';
 import EmptyState from '@shared/components/empty-state/empty-state';
 import ParentTagList from '@shared/components/parent-tag-list/parent-tag-list';
 import TagCheckTree from '@shared/components/tag-check-tree/tag-check-tree';
-import { flattenTree } from '@shared/utils/build-tree';
 
 import TagSelectField from './tag-select-field/tag-select-field';
 
@@ -39,7 +38,7 @@ const FilterModal = ({
 
   const activeRoot =
     roots.find((root) => root.tagId === activeRootId) ?? roots[0];
-  const flatTags = useMemo(() => flattenTree(roots), [roots]);
+  const { data: flatTags = [] } = useFlatTags();
   const selectedTags = flatTags.filter((tag) =>
     selectedIds.includes(tag.tagId),
   );

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { Icon } from '@cds/icon';
-import { Modal } from '@cds/ui';
+import { Button, Modal } from '@cds/ui';
 
 import { useGetTag } from '@shared/apis/tag/queries';
 import ParentTagList from '@shared/components/parent-tag-list/parent-tag-list';
@@ -96,19 +96,14 @@ const FilterModal = ({
                 )}
 
                 <div className={styles.footer}>
-                  {/** TODO 임시 버튼 공통 버튼 수정후 교체하겠습니다. */}
                   <Modal.Close>
-                    <button type="button" className={styles.cancelButton}>
+                    <Button size="md" variant="outlined">
                       취소
-                    </button>
+                    </Button>
                   </Modal.Close>
-                  <button
-                    type="button"
-                    className={styles.applyButton}
-                    onClick={handleApply}
-                  >
+                  <Button size="md" variant="solid" onClick={handleApply}>
                     적용하기
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/apps/client/src/features/filter-modal/filter-modal.tsx
+++ b/apps/client/src/features/filter-modal/filter-modal.tsx
@@ -21,6 +21,7 @@ interface FilterModalProps {
 const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
   const { data: roots = [] } = useGetTag();
   const [activeRootId, setActiveRootId] = useState<number>();
+  const [appliedIds, setAppliedIds] = useState<number[]>([]);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   const activeRoot =
@@ -39,12 +40,18 @@ const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
   };
 
   const handleApply = () => {
+    setAppliedIds(selectedIds);
     onApply(selectedIds);
     onOpenChange(false);
   };
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setSelectedIds(appliedIds);
+    onOpenChange(nextOpen);
+  };
+
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal open={open} onOpenChange={handleOpenChange}>
       <Modal.Content ariaLabel="태그 필터링">
         <div className={styles.container}>
           <div className={styles.header}>
@@ -92,10 +99,7 @@ const FilterModal = ({ open, onOpenChange, onApply }: FilterModalProps) => {
                   </Modal.Close>
                   <button
                     type="button"
-                    className={styles.applyButton({
-                      disabled: selectedIds.length === 0,
-                    })}
-                    disabled={selectedIds.length === 0}
+                    className={styles.applyButton({ disabled: false })}
                     onClick={handleApply}
                   >
                     적용하기

--- a/apps/client/src/shared/apis/tag/queries.ts
+++ b/apps/client/src/shared/apis/tag/queries.ts
@@ -34,3 +34,15 @@ export const useGetTag = () => {
     select: selectTagTree,
   });
 };
+
+/**
+ * 태그 목록 조회 (평탄한 목록).
+ * useGetTag와 같은 쿼리를 공유하되, 트리로 조립했다가 다시 펼치는 과정 없이 바로 평탄한 목록을 반환.
+ */
+export const useFlatTags = () => {
+  return useQuery({
+    queryKey: TAG_KEY.GET_ALL(),
+    queryFn: getTag,
+    select: (response) => response.data?.tags?.filter(hasTagId) ?? [],
+  });
+};

--- a/apps/client/src/shared/components/parent-tag-list/parent-tag-list.css.ts
+++ b/apps/client/src/shared/components/parent-tag-list/parent-tag-list.css.ts
@@ -5,7 +5,6 @@ import { themeVars } from '@cds/ui';
 export const container = style({
   position: 'relative',
   height: '100%',
-  maxHeight: '25.6rem',
   padding: '0.4rem 1.8rem 0.4rem 0',
   borderRight: `1px solid ${themeVars.color.grey200}`,
   overflowY: 'auto',

--- a/apps/client/src/shared/utils/build-tree.ts
+++ b/apps/client/src/shared/utils/build-tree.ts
@@ -42,7 +42,3 @@ export const buildTree = <T, K>(
 
   return roots;
 };
-
-/** 중첩 트리를 평면 목록으로 변환 (`buildTree`의 역연산). */
-export const flattenTree = <T>(nodes: TreeNode<T>[]): TreeNode<T>[] =>
-  nodes.flatMap((node) => [node, ...flattenTree(node.children)]);

--- a/apps/client/src/shared/utils/build-tree.ts
+++ b/apps/client/src/shared/utils/build-tree.ts
@@ -42,3 +42,7 @@ export const buildTree = <T, K>(
 
   return roots;
 };
+
+/** 중첩 트리를 평면 목록으로 변환 (`buildTree`의 역연산). */
+export const flattenTree = <T>(nodes: TreeNode<T>[]): TreeNode<T>[] =>
+  nodes.flatMap((node) => [node, ...flattenTree(node.children)]);

--- a/packages/cds-ui/src/components/button/button.css.ts
+++ b/packages/cds-ui/src/components/button/button.css.ts
@@ -1,4 +1,3 @@
-import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '../../styles';
@@ -20,12 +19,10 @@ export const button = recipe({
         borderRadius: '8px',
       },
       md: {
-        width: '10.8rem',
-        height: '3.2rem',
+        width: '12rem',
+        height: '3.6rem',
         borderRadius: '8px',
-        position: 'relative',
-        isolation: 'isolate',
-        ...themeVars.fontStyles.label_sb_12,
+        ...themeVars.fontStyles.body_m_16,
       },
       lg: {
         width: '100%',
@@ -88,33 +85,17 @@ export const button = recipe({
     {
       variants: { size: 'md', variant: 'outlined' },
       style: {
-        border: '1px solid transparent',
-        selectors: {
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            inset: '-1px',
-            borderRadius: '8px',
-            background: themeVars.color.gradient01,
-            zIndex: themeVars.zIndex.deep,
-            pointerEvents: 'none',
-          },
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            inset: '-1px',
-            borderRadius: '8px',
-            background: themeVars.color.gradient03,
-            backgroundClip: 'content-box',
-            border: '1px solid transparent',
-            zIndex: themeVars.zIndex.back,
-            pointerEvents: 'none',
-          },
-          '&:hover::after': {
-            borderWidth: '2px',
-            transition: 'border-width 0.1s ease',
-          },
-        },
+        backgroundColor: themeVars.color.white,
+        color: themeVars.color.grey700,
+        border: `1px solid ${themeVars.color.grey400}`,
+      },
+    },
+    {
+      variants: { size: 'md', disabled: true },
+      style: {
+        backgroundColor: themeVars.color.grey600,
+        color: themeVars.color.white,
+        border: 'none',
       },
     },
 
@@ -134,7 +115,7 @@ export const button = recipe({
       style: {
         backgroundColor: 'transparent',
         color: themeVars.color.grey700,
-        border: `1px solid ${themeVars.color.grey700}`,
+        border: `1px solid ${themeVars.color.grey400}`,
       },
     },
     {
@@ -151,13 +132,4 @@ export const button = recipe({
     variant: 'solid',
     disabled: false,
   },
-});
-
-export const outlinedText = style({
-  position: 'relative',
-  zIndex: 1,
-  backgroundImage: themeVars.color.gradient01,
-  backgroundClip: 'text',
-  WebkitBackgroundClip: 'text',
-  color: 'transparent',
 });

--- a/packages/cds-ui/src/components/button/button.tsx
+++ b/packages/cds-ui/src/components/button/button.tsx
@@ -22,9 +22,6 @@ const Button = ({
   disabled = false,
   textSize,
 }: ButtonProps) => {
-  const applyOutlinedText =
-    size === 'md' && variant === 'outlined' && typeof children === 'string';
-
   return (
     <button
       type="button"
@@ -32,11 +29,7 @@ const Button = ({
       disabled={disabled}
       className={styles.button({ size, variant, disabled, textSize })}
     >
-      {applyOutlinedText ? (
-        <span className={styles.outlinedText}>{children}</span>
-      ) : (
-        children
-      )}
+      {children}
     </button>
   );
 };


### PR DESCRIPTION
## 📌 Summary

> - #294

메모 검색/목록에서 태그로 필터링할 때 사용할 `FilterModal` 컴포넌트를 구현했습니다.

좌측에는 루트 태그 목록(`ParentTagList`)을 우측에는 선택된 태그 필드(`TagSelectField`)와 태그 체크 트리(`TagCheckTree`)를 배치했습니다. 

또한 모달에서 편집 중인 선택값과 마지막으로 적용한 선택값을 분리해 관리해서 적용하지 않은 변경사항은 취소하거나 모달을 닫을 때 되돌아가도록 처리했습니다.

## 📚 Tasks

- `FilterModal` 컴포넌트 구현
- `build-tree.ts`에 `flattenTree` 유틸 추가 (`buildTree`의 역연산)

## 🔍 Describe


### 상태 관리

```ts
const { data: roots = [] } = useGetTag();
const [activeRootId, setActiveRootId] = useState<number>();
const [appliedIds, setAppliedIds] = useState<number[]>([]);
const [selectedIds, setSelectedIds] = useState<number[]>([]);
```

- `roots`
  - 서버에서 조회한 태그 트리입니다.
  - `useGetTag`가 평면 태그 목록을 중첩 트리 형태로 변환해 반환하므로 최상위 태그 배열을 사용하게 됩니다.
  - 조회 전에도 안전하게 렌더링할 수 있도록 기본값을 `[]`로 지정했습니다.

- `activeRootId`
  - 좌측 `ParentTagList`에서 현재 활성화된 루트 태그의 ID입니다.
  - 선택한 루트 태그에 따라 우측 `TagCheckTree`에 표시할 트리가 바뀝니다.

- `selectedIds`
  - 모달에서 사용자가 현재 체크하거나 해제하며 편집 중인 태그 ID 목록입니다.
  - 트리의 체크 상태, 선택 태그 칩 목록, 선택 개수 표시에 사용됩니다.

- `appliedIds`
  - 마지막으로 **적용하기**를 눌러 확정한 태그 ID 목록입니다.
  - 사용자가 태그 선택을 수정했더라도 적용하지 않고 취소·닫기하면 `selectedIds`를 이 값으로 되돌립니다.

### 활성 루트 태그와 선택 태그 계산

```ts
const activeRoot =
  roots.find((root) => root.tagId === activeRootId) ?? roots[0];
```

`activeRootId`에 해당하는 루트 태그를 찾습니다. 모달을 처음 열었을 때는 아직 선택한 루트 태그가 없으므로 첫 번째 루트 태그(`roots[0]`)를 기본으로 표시합니다.


### 태그 선택/해제

```ts
const handleToggle = (tagId: number) => {
  setSelectedIds((prev) =>
    prev.includes(tagId)
      ? prev.filter((id) => id !== tagId)
      : [...prev, tagId],
  );
};
```

선택된 태그는 ID 배열 하나로 관리합니다.

이미 선택된 태그를 클릭하면 ID를 제거하고 선택되지 않은 태그를 클릭하면 ID를 추가합니다. 이 핸들러는 다음 두 UI에서 함께 사용합니다.

- `TagCheckTree`의 체크박스 클릭
- `TagSelectField`의 태그 칩 제거 버튼 클릭

따라서 트리에서 체크 해제하는 동작과 칩에서 제거하는 동작의 상태 변경 규칙을 하나로 통일했습니다.

### 적용 / 취소 / 닫기

```ts
const handleApply = () => {
  setAppliedIds(selectedIds);
  onApply(selectedIds);
  onOpenChange(false);
};
```

**적용하기**를 누르면 현재 편집 중인 `selectedIds`를 확정값인 `appliedIds`에 저장하고 상위 컴포넌트의 `onApply` 콜백에 전달한 뒤 모달을 닫습니다.

선택값이 빈 배열이어도 적용할 수 있습니다. 상위 컴포넌트에서는 빈 배열을 받아 필터를 해제하는 흐름에 사용할 수 있습니다.

```ts
const handleOpenChange = (nextOpen: boolean) => {
  if (!nextOpen) setSelectedIds(appliedIds);
  onOpenChange(nextOpen);
};
```

취소 버튼, 닫기 버튼, 오버레이 클릭 등으로 모달이 닫힐 때는 `selectedIds`를 마지막 적용값인 `appliedIds`로 복원합니다.

예를 들어 `[1]`이 적용된 상태에서 사용자가 모달 안에서 `[1, 2]`로 수정한 뒤 취소하면 다음에 모달을 열었을 때는 적용되지 않은 `2`가 제거된 `[1]` 상태를 유지합니다.

### `flattenTree` 유틸

```ts
export const flattenTree = <T>(nodes: TreeNode<T>[]): TreeNode<T>[] =>
  nodes.flatMap((node) => [node, ...flattenTree(node.children)]);
```

기존 `buildTree`가 평면 태그 목록을 중첩 트리로 변환한다면 `flattenTree`는 중첩 트리를 다시 평면 배열로 변환합니다.

현재는 선택한 태그 ID를 태그 객체 목록으로 변환하는 데 사용하며,이후 트리 전체에서 태그를 조회해야 하는 경우에도 공통으로 사용할 수 있습니다.


## 👀 To Reviewer



## 📸 Screenshot
<img width="903" height="689" alt="image" src="https://github.com/user-attachments/assets/d4a19460-bd54-45c4-969a-89cd2abbad76" />


https://github.com/user-attachments/assets/95f3b631-bb36-4b20-86c2-c0bbb527cc91
<img width="948" height="754" alt="image" src="https://github.com/user-attachments/assets/66e88438-1384-41ab-a5e9-f5436a2040d8" />

