### PR TITLE
Feat(cds): HoverTooltip 컴포넌트 구현

### DIFF
--- a/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.css.ts
+++ b/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '../../styles';
+
+export const wrapper = style({
+  position: 'relative',
+  display: 'inline-flex',
+});
+
+export const tooltip = style({
+  position: 'absolute',
+  bottom: '100%',
+  left: 0,
+  transform: 'translateY(-0.4rem)',
+  visibility: 'hidden',
+  opacity: 0,
+  transition: 'opacity 0.15s ease',
+  zIndex: themeVars.zIndex.default,
+  pointerEvents: 'none',
+
+  selectors: {
+    [`${wrapper}:hover &`]: {
+      visibility: 'visible',
+      opacity: 1,
+    },
+  },
+});

--- a/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.stories.tsx
+++ b/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Icon } from '@cds/icon';
+
+import HoverTooltip from './hover-tooltip';
+
+const meta: Meta<typeof HoverTooltip> = {
+  title: 'Components/HoverTooltip',
+  component: HoverTooltip,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ paddingTop: '3rem', paddingLeft: '3rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: '툴팁 제목',
+    },
+    description: {
+      control: 'text',
+      description: '툴팁 설명 (선택)',
+    },
+    children: {
+      description: '호버하면 툴팁을 띄우는 트리거 엘리먼트',
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: '사진 및 파일 업로드',
+    children: <Icon name="ic_plus" size={24} color="grey700" />,
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: '메모 삭제하기',
+    description: '삭제된 메모는 다시 복구할 수 없어요',
+    children: <Icon name="ic_trash" size={24} color="grey700" />,
+  },
+};

--- a/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/cds-ui/src/components/hover-tooltip/hover-tooltip.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+
+import Tooltip from '../tooltip/tooltip';
+
+import * as styles from './hover-tooltip.css';
+
+interface HoverTooltipProps {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}
+
+const HoverTooltip = ({ title, description, children }: HoverTooltipProps) => {
+  return (
+    <div className={styles.wrapper}>
+      {children}
+      <div className={styles.tooltip}>
+        <Tooltip title={title} description={description} />
+      </div>
+    </div>
+  );
+};
+
+export default HoverTooltip;

--- a/packages/cds-ui/src/components/index.ts
+++ b/packages/cds-ui/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './button/button';
 export { default as File } from './file/file';
 export { default as FloatingButton } from './floating-button/floating-button';
+export { default as HoverTooltip } from './hover-tooltip/hover-tooltip';
 export { default as ImageContainer } from './image-container/image-container';
 export { default as Modal } from './modal/modal';
 export { default as PageTitle } from './page-title/page-title';


### PR DESCRIPTION
## 📌 Summary

> 관련 있는 Issue를 태그해주세요. (e.g. > - #100)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📚 Tasks

- HoverTooltip 구현

## 🔍 Describe

### 기존 Tooltip을 사용하지 않은 이유
기존 Tooltip 컴포넌트는 hover 시 로직을 갖고 있지 않아요.
-> 외부에서 `:hover` selector나 조건부 렌더링으로 Tooltip을 제어해요.

이번 브랜치에서 필요한 내용은 Hover 시 툴팁이 자동으로 보이는 것이였어요.
Tooltip 컴포넌트를 리팩토링 하려고 했지만 지금 고치기엔 충돌날 부분(사이드바쪽)도 있고, 시간 문제도 있어서 별도로 구현했어요.
-> 우선순위를 높게 가져가기에는 다른 태스크들이 더 중요하다고 판단했어요

### 스프린트 이후 Tooltip, HoverTooltip 개선 방향성
1. Tooltip, HoverTooltip을 하나로 합침
2. props 계획
```ts
<Tooltip withArrow={boolean} offset={top} content={ReactNode}>
  {children}
</Tooltip>
```
이런 방식으로 
- 툴팁에 대한 내용은 content에 JSX를 넘기고,
- offset으로 툴팁이 뜰 위치를 조절하고,
- 툴팁을 트리거하는 역할은 children이 맡도록 

하려고 계획중이에요.

### 태스크 할당
[노션](https://app.notion.com/p/Tooltip-3c9e58c2d57c8092a1b4f9718d31a388?source=copy_link)에 태스크 할당해두었습니다!

이 작업은 스프린트 끝나는대로 우선순위를 높게 가져가 작업하려고 해요


<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
