### PR TITLE
Refactor(client, cds-ui): sidebar 스타일 및 애니메이션 개선

### DIFF
--- a/apps/client/src/shared/components/layouts/dashboard-layout/dashboard-layout.css.ts
+++ b/apps/client/src/shared/components/layouts/dashboard-layout/dashboard-layout.css.ts
@@ -3,14 +3,10 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@cds/ui';
 
 export const root = style({
+  display: 'flex',
   minHeight: '100vh',
   minWidth: '100vw',
   backgroundColor: themeVars.color.grey50,
-});
-
-export const content = style({
-  zIndex: themeVars.zIndex.sidebar,
-  display: 'flex',
 });
 
 export const mainContent = style({

--- a/apps/client/src/shared/components/layouts/dashboard-layout/dashboard-layout.tsx
+++ b/apps/client/src/shared/components/layouts/dashboard-layout/dashboard-layout.tsx
@@ -9,10 +9,8 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
     <SidebarProvider>
       <div className={styles.root}>
-        <div className={styles.content}>
-          <Sidebar />
-          <div className={styles.mainContent}>{children}</div>
-        </div>
+        <Sidebar />
+        <div className={styles.mainContent}>{children}</div>
       </div>
     </SidebarProvider>
   );

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
@@ -1,9 +1,10 @@
 import { style } from '@vanilla-extract/css';
 
 import { zIndex } from '@cds/token';
-import { themeVars } from '@cds/ui';
+import { slideInLeft, themeVars } from '@cds/ui';
 
 export const sidebar = style({
+  position: 'sticky',
   display: 'flex',
   flexDirection: 'column',
   backgroundColor: themeVars.color.grey50,
@@ -11,7 +12,8 @@ export const sidebar = style({
   padding: '2rem',
   height: '100vh',
   flexShrink: '0',
-  transition: 'width 0.2s ease',
+  animation: `${slideInLeft} 0.3s cubic-bezier(0.4, 0, 0.2, 1)`,
+  transition: 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
   selectors: {
     '&[data-expanded="true"]': { width: '26rem' },
     '&[data-expanded="false"]': { width: '8rem' },

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
@@ -5,6 +5,7 @@ import { slideInLeft, themeVars } from '@cds/ui';
 
 export const sidebar = style({
   position: 'sticky',
+  top: '0',
   display: 'flex',
   flexDirection: 'column',
   backgroundColor: themeVars.color.grey50,

--- a/packages/cds-ui/src/styles/animations.css.ts
+++ b/packages/cds-ui/src/styles/animations.css.ts
@@ -20,6 +20,15 @@ export const slideInRight = keyframes({
   },
 });
 
+export const slideInLeft = keyframes({
+  '0%': {
+    transform: 'translateX(-100%)',
+  },
+  '100%': {
+    transform: 'translateX(0)',
+  },
+});
+
 export const fadeIn = keyframes({
   '0%': { opacity: 0 },
   '100%': { opacity: 1 },

--- a/packages/cds-ui/src/styles/index.ts
+++ b/packages/cds-ui/src/styles/index.ts
@@ -1,7 +1,7 @@
 import './reset.css';
 import './global.css';
 
-export { fadeIn, slideInRight, slideInUp } from './animations.css';
+export { fadeIn, slideInLeft, slideInRight, slideInUp } from './animations.css';
 export type { Sprinkles } from './sprinkles.css';
 export { sprinkles } from './sprinkles.css';
 export { themeClass, themeVars } from './theme.css';


### PR DESCRIPTION
## 📌 Summary

> - #327 

sidebar 스타일 및 애니메이션 개선

## 📚 Tasks

- slideInLeft` 키프레임 추가 (@cds/ui)
- sidebar를 `position: sticky`로 변경해 스크롤 시 고정

## 🔍 Describe

- `slideInLeft`을 추가하고 `@cds/ui`에서 export했어요
- sidebar에 진입 애니메이션(`slideInLeft`)을 적용했어요
- sidebar를 `position: sticky`로 두어 스크롤 중에도 화면에 고정되게 했어요


## 👀 To Reviewer

간단한 작업이라 슈슈슝 봐주셔도 됩니다 !!!

## 📸 Screenshot


> before
> 
> https://github.com/user-attachments/assets/55cf44c2-29d4-4005-a577-3175c8cc457d

> after
> 
> https://github.com/user-attachments/assets/30c2bc4f-665f-4e06-a2db-a1390cb42a22
