### PR TITLE
Feat(client): 메모 목록 페이지 태그 필터 기능 연동

### DIFF
--- a/apps/client/src/pages/memos/memos-page.css.ts
+++ b/apps/client/src/pages/memos/memos-page.css.ts
@@ -6,7 +6,10 @@ const HEADER_MIN_WIDTH = '800px';
 
 export const container = style({
   width: '100%',
+  height: '100%',
   paddingInline: '4rem',
+  display: 'flex',
+  flexDirection: 'column',
   containerType: 'inline-size',
   containerName: HEADER_CONTAINER,
 });

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -19,12 +19,13 @@ const AllMemoPage = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedTagIds = searchParams.getAll('tag').map(Number);
-  const tagIds = selectedTagIds.length ? selectedTagIds : undefined;
+  const activeTagIds = selectedTagIds.length ? selectedTagIds : undefined;
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   const { data: flatTags = [] } = useFlatTags();
+  const tagsById = new Map(flatTags.map((tag) => [tag.tagId, tag]));
   const filterChips = selectedTagIds
-    .map((id) => flatTags.find((tag) => tag.tagId === id))
+    .map((id) => tagsById.get(id))
     .filter((tag) => tag !== undefined)
     .map((tag) => ({ id: tag.tagId, tagName: tag.name }));
 
@@ -33,8 +34,8 @@ const AllMemoPage = () => {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetAllMemo(tagIds);
-  const { data: totalCount } = useGetMemoTotalCount(tagIds);
+  } = useGetAllMemo(activeTagIds);
+  const { data: totalCount } = useGetMemoTotalCount(activeTagIds);
 
   const handleApplyFilter = (tagIds: number[]) => {
     const nextParams = new URLSearchParams();

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -24,10 +24,10 @@ const AllMemoPage = () => {
 
   const { data: flatTags = [] } = useFlatTags();
   const tagsById = new Map(flatTags.map((tag) => [tag.tagId, tag]));
-  const filterChips = selectedTagIds
-    .map((id) => tagsById.get(id))
-    .filter((tag) => tag !== undefined)
-    .map((tag) => ({ id: tag.tagId, tagName: tag.name }));
+  const filterChips = selectedTagIds.flatMap((id) => {
+    const tag = tagsById.get(id);
+    return tag ? [{ id: tag.tagId, tagName: tag.name }] : [];
+  });
 
   const {
     data: memosList,

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -38,9 +38,11 @@ const AllMemoPage = () => {
   const { data: totalCount } = useGetMemoTotalCount(activeTagIds);
 
   const handleApplyFilter = (tagIds: number[]) => {
-    const nextParams = new URLSearchParams();
-    tagIds.forEach((id) => nextParams.append('tag', String(id)));
-    setSearchParams(nextParams);
+    setSearchParams((prev) => {
+      prev.delete('tag');
+      tagIds.forEach((id) => prev.append('tag', String(id)));
+      return prev;
+    });
   };
 
   const handleRemoveFilter = (tagId: number) => {

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -3,6 +3,7 @@ import FilterModal from '@features/filter-modal/filter-modal';
 import { PATH } from '@router/path';
 import { useNavigate, useSearchParams } from 'react-router';
 
+import { useFlatTags } from '@shared/apis/tag/queries';
 import EmptyView from '@shared/components/empty-view/empty-view';
 
 import { useGetAllMemo, useGetMemoTotalCount } from './apis/queries';
@@ -16,10 +17,16 @@ import emptyImage from '/empty.svg';
 
 const AllMemoPage = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const tagParam = searchParams.get('tag');
-  const tagIds = tagParam !== null ? [Number(tagParam)] : undefined;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedTagIds = searchParams.getAll('tag').map(Number);
+  const tagIds = selectedTagIds.length ? selectedTagIds : undefined;
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+
+  const { data: flatTags = [] } = useFlatTags();
+  const filterChips = selectedTagIds
+    .map((id) => flatTags.find((tag) => tag.tagId === id))
+    .filter((tag) => tag !== undefined)
+    .map((tag) => ({ id: tag.tagId, tagName: tag.name }));
 
   const {
     data: memosList,
@@ -28,6 +35,16 @@ const AllMemoPage = () => {
     fetchNextPage,
   } = useGetAllMemo(tagIds);
   const { data: totalCount } = useGetMemoTotalCount(tagIds);
+
+  const handleApplyFilter = (tagIds: number[]) => {
+    const nextParams = new URLSearchParams();
+    tagIds.forEach((id) => nextParams.append('tag', String(id)));
+    setSearchParams(nextParams);
+  };
+
+  const handleRemoveFilter = (tagId: number) => {
+    handleApplyFilter(selectedTagIds.filter((id) => id !== tagId));
+  };
 
   const loadMoreRef = useInfiniteScroll({
     hasNextPage,
@@ -52,16 +69,16 @@ const AllMemoPage = () => {
               <Header
                 title="전체 메모"
                 count={totalCount ?? 0}
-                isFilterActive={false}
+                isFilterActive={selectedTagIds.length > 0}
                 onOpenFilter={() => setIsFilterOpen(true)}
-                filterChips={[]}
-                onRemoveFilter={() => {}}
+                filterChips={filterChips}
+                onRemoveFilter={handleRemoveFilter}
               />
               <FilterModal
                 open={isFilterOpen}
-                selectedTagIds={[]}
+                selectedTagIds={selectedTagIds}
                 onOpenChange={setIsFilterOpen}
-                onApply={() => setIsFilterOpen(false)}
+                onApply={handleApplyFilter}
               />
             </div>
             {/* 카드 선택/드래그, 상세 페이지 연결 전까지 임시 값 전달 */}

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -52,47 +52,53 @@ const AllMemoPage = () => {
     fetchNextPage,
   });
 
+  const isFilterActive = selectedTagIds.length > 0;
+  const showHeaderSection = isFilterActive || totalCount !== 0;
+
   return (
-    <>
-      <div className={styles.container}>
-        {totalCount === 0 ? (
-          <EmptyView
-            imgSrc={emptyImage}
-            title="작성된 메모가 없습니다."
-            description="새 메모 창에 들어가서 새로운 메모를 생성해보세요."
-            buttonText="메모 작성하러 가기"
-            onButtonClick={() => navigate(PATH.MEMO)}
-          />
-        ) : (
-          <>
-            <div className={styles.headerContainer}>
-              <Header
-                title="전체 메모"
-                count={totalCount ?? 0}
-                isFilterActive={selectedTagIds.length > 0}
-                onOpenFilter={() => setIsFilterOpen(true)}
-                filterChips={filterChips}
-                onRemoveFilter={handleRemoveFilter}
-              />
-              <FilterModal
-                open={isFilterOpen}
-                selectedTagIds={selectedTagIds}
-                onOpenChange={setIsFilterOpen}
-                onApply={handleApplyFilter}
-              />
-            </div>
-            {/* 카드 선택/드래그, 상세 페이지 연결 전까지 임시 값 전달 */}
-            <MemoCardList
-              cards={memosList ?? []}
-              isSelected={false}
-              isDragging={false}
-              onClickCard={() => {}}
+    <div className={styles.container}>
+      {showHeaderSection && (
+        <>
+          <div className={styles.headerContainer}>
+            <Header
+              title="전체 메모"
+              count={totalCount ?? 0}
+              isFilterActive={isFilterActive}
+              onOpenFilter={() => setIsFilterOpen(true)}
+              filterChips={filterChips}
+              onRemoveFilter={handleRemoveFilter}
             />
-            <div ref={loadMoreRef} />
-          </>
-        )}
-      </div>
-    </>
+          </div>
+          <FilterModal
+            open={isFilterOpen}
+            selectedTagIds={selectedTagIds}
+            onOpenChange={setIsFilterOpen}
+            onApply={handleApplyFilter}
+          />
+        </>
+      )}
+
+      {totalCount === 0 ? (
+        <EmptyView
+          imgSrc={emptyImage}
+          title="작성된 메모가 없습니다."
+          description="새 메모 창에 들어가서 새로운 메모를 생성해보세요."
+          buttonText="메모 작성하러 가기"
+          onButtonClick={() => navigate(PATH.MEMO)}
+        />
+      ) : (
+        <>
+          {/* 카드 선택/드래그, 상세 페이지 연결 전까지 임시 값 전달 */}
+          <MemoCardList
+            cards={memosList ?? []}
+            isSelected={false}
+            isDragging={false}
+            onClickCard={() => {}}
+          />
+          <div ref={loadMoreRef} />
+        </>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📌 Summary

> - #325

메모 목록 페이지(`AllMemoPage`)에 태그 필터 기능을 실제 데이터와 연동합니다. 

## 📚 Tasks

- 다중 태그 필터 상태를 URL 쿼리 파라미터와 연동
- 필터 결과가 0건이어도 필터 중이면 헤더가 유지되도록 노출 조건 수정


## 🔍 Describe


**헤더 노출 조건 수정**
기존에는 `totalCount === 0`이면 무조건 `EmptyView`만 보여주고 헤더/필터 UI 자체를 렌더링하지 않았습니다. 필터를 적용한 결과가 0건일 때 필터 칩이나 필터 버튼까지 통째로 사라져 사용자가 필터를 해제할 방법이 없어지는 문제가 있었는데 `isFilterActive || totalCount !== 0` 조건(`showHeaderSection`)으로 바꿔 필터가 걸려있는 동안에는 결과가 없어도 헤더가 유지되도록 했습니다.

**레이아웃 수정**
empty-view가 세로 가운데 정렬이 안되어서(제가 필터링버튼 ui구현 브랜치에서 센터를 지운것같아요 ,,,,) `memos-page.css.ts`의 `container`에 `height: 100%`와 `display: flex; flex-direction: column`을 추가해 수정했습니다.


## 👀 To Reviewer
아침에 알바가있어서 대강올려봅니다.... 퇴근하고 리팩토링? 뭐이런거 해볼게욥 뭔가 성급하게해서 마음에 안드는 것 같기도하구
태그가 있는데 메모가 없을 경우 empty뷰는 header유지한채로 empty가 뜨는 것이 자연스러워서 임의로 해두었는데 디자인분들이 싫다하면 확 빼버릴게욥!


## 📸 Screenshot

https://github.com/user-attachments/assets/fb937721-e3c5-4371-9adf-8e96111780cf


