### PR TITLE
Feat(client): 메모 드래그 앤 드롭 AI 패널 연동

### DIFF
--- a/apps/client/src/features/ai-panel/ai-panel.css.ts
+++ b/apps/client/src/features/ai-panel/ai-panel.css.ts
@@ -25,3 +25,11 @@ export const content = style({
   overflowY: 'auto',
   padding: '1.6rem',
 });
+
+export const chatWrapper = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minHeight: 0,
+});

--- a/apps/client/src/features/ai-panel/ai-panel.tsx
+++ b/apps/client/src/features/ai-panel/ai-panel.tsx
@@ -1,8 +1,13 @@
+import { DragEvent, useRef, useState } from 'react';
+import { SelectedMemoType } from '@features/ai-panel/types/ai-panel.types';
+
 import ConfirmModal from '@shared/components/confirm-modal/confirm-modal';
+import { MEMO_DRAG_DATA_FORMAT } from '@shared/constants/memo-drag-data';
 
 import { useAiPanel } from './ai-panel-context';
 import AiPanelHeader from './components/ai-panel-header/ai-panel-header';
 import AiPanelChat from './components/chat/ai-panel-chat/ai-panel-chat';
+import MemoDropOverlay from './components/memo-drop-overlay/memo-drop-overlay';
 import PromptInput from './components/prompt-input/prompt-input';
 import SuggestedMemoList, {
   SuggestedMemo,
@@ -13,6 +18,9 @@ import * as styles from './ai-panel.css';
 
 const AI_PANEL_TITLE_ID = 'ai-panel-title';
 
+const isMemoDrag = (event: DragEvent<HTMLElement>) =>
+  event.dataTransfer.types.includes(MEMO_DRAG_DATA_FORMAT);
+
 interface SuggestedMemoSection {
   memos: SuggestedMemo[];
   onSelectMemo?: (memo: SuggestedMemo) => void;
@@ -20,15 +28,47 @@ interface SuggestedMemoSection {
 }
 
 interface AiPanelProps {
-  isDragOver?: boolean;
   suggestedMemoSection?: SuggestedMemoSection;
 }
 
-const AiPanel = ({
-  isDragOver = false,
-  suggestedMemoSection,
-}: AiPanelProps) => {
+const AiPanel = ({ suggestedMemoSection }: AiPanelProps) => {
   const { isOpen, selectedMemos, close, addMemo, removeMemo } = useAiPanel();
+
+  const [isDragOver, setIsDragOver] = useState(false);
+  const dragDepthRef = useRef(0);
+
+  const handleDragEnter = (event: DragEvent<HTMLElement>) => {
+    if (!isMemoDrag(event)) return;
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDragOver(true);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLElement>) => {
+    if (!isMemoDrag(event)) return;
+    event.preventDefault();
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLElement>) => {
+    if (!isMemoDrag(event)) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDragOver(false);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLElement>) => {
+    dragDepthRef.current = 0;
+    setIsDragOver(false);
+    if (!isMemoDrag(event)) return;
+    event.preventDefault();
+
+    try {
+      const raw = event.dataTransfer.getData(MEMO_DRAG_DATA_FORMAT);
+      addMemo(JSON.parse(raw) as SelectedMemoType);
+    } catch {
+      // 유효한 메모 드래그 데이터가 아니면 무시
+    }
+  };
+
   const {
     messages,
     isLoading,
@@ -59,7 +99,14 @@ const AiPanel = ({
   if (!isOpen) return null;
 
   return (
-    <aside className={styles.container} aria-labelledby={AI_PANEL_TITLE_ID}>
+    <aside
+      className={styles.container}
+      aria-labelledby={AI_PANEL_TITLE_ID}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <AiPanelHeader
         titleId={AI_PANEL_TITLE_ID}
         onCreateNewChat={handleCreateNewChat}
@@ -67,21 +114,25 @@ const AiPanel = ({
       />
 
       <div className={styles.content}>
-        {shouldShowSuggestedMemos && (
-          <SuggestedMemoList
-            memos={suggestedMemoSection.memos}
-            onSelectMemo={handleSelectSuggestedMemo}
-            onOpenMemo={suggestedMemoSection.onOpenMemo}
-          />
-        )}
+        <div className={styles.chatWrapper}>
+          {shouldShowSuggestedMemos && (
+            <SuggestedMemoList
+              memos={suggestedMemoSection.memos}
+              onSelectMemo={handleSelectSuggestedMemo}
+              onOpenMemo={suggestedMemoSection.onOpenMemo}
+            />
+          )}
 
-        <AiPanelChat
-          messages={messages}
-          isAnswerLoading={isAnswerLoading}
-          answerGeneratingMemoCount={answerGeneratingMemoCount}
-          onRegenerate={handleRegenerate}
-          onSaveToMemo={handleSaveToMemo}
-        />
+          <AiPanelChat
+            messages={messages}
+            isAnswerLoading={isAnswerLoading}
+            answerGeneratingMemoCount={answerGeneratingMemoCount}
+            onRegenerate={handleRegenerate}
+            onSaveToMemo={handleSaveToMemo}
+          />
+
+          {isDragOver && <MemoDropOverlay />}
+        </div>
 
         <PromptInput
           value={promptValue}
@@ -91,7 +142,6 @@ const AiPanel = ({
           disabled={isLoading}
           selectedMemos={selectedMemos}
           onRemoveMemo={removeMemo}
-          isDragOver={isDragOver}
         />
       </div>
 

--- a/apps/client/src/features/ai-panel/components/memo-drop-overlay/memo-drop-overlay.css.ts
+++ b/apps/client/src/features/ai-panel/components/memo-drop-overlay/memo-drop-overlay.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@cds/ui';
+
+export const overlay = style({
+  position: 'absolute',
+  inset: 0,
+  zIndex: themeVars.zIndex.panelOverlay,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.6rem',
+  borderRadius: '12px',
+  border: `2px dashed ${themeVars.color.grey500}`,
+  backgroundColor: themeVars.color.opacity90,
+});
+
+export const iconBox = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '4.4rem',
+  height: '4.4rem',
+  borderRadius: '8px',
+  border: `1px solid ${themeVars.color.grey400}`,
+  backgroundColor: themeVars.color.white,
+});
+
+export const text = style({
+  ...themeVars.fontStyles.title_m_20,
+  color: themeVars.color.grey800,
+});

--- a/apps/client/src/features/ai-panel/components/memo-drop-overlay/memo-drop-overlay.tsx
+++ b/apps/client/src/features/ai-panel/components/memo-drop-overlay/memo-drop-overlay.tsx
@@ -1,0 +1,14 @@
+import { Icon } from '@cds/icon';
+
+import * as styles from './memo-drop-overlay.css';
+
+const MemoDropOverlay = () => {
+  return (
+    <div className={styles.overlay}>
+      <Icon name="ic_memo_36" size={36} className={styles.iconBox} />
+      <p className={styles.text}>메모를 해당 패널로 드롭해주세요.</p>
+    </div>
+  );
+};
+
+export default MemoDropOverlay;

--- a/apps/client/src/features/ai-panel/components/prompt-input/prompt-input.css.ts
+++ b/apps/client/src/features/ai-panel/components/prompt-input/prompt-input.css.ts
@@ -1,31 +1,19 @@
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@cds/ui';
 
-export const container = recipe({
-  base: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1rem',
-    backgroundColor: themeVars.color.white,
-    borderRadius: '12px',
-    padding: '1.6rem 1.8rem',
-    border: `1px solid ${themeVars.color.grey300}`,
-    transition: 'border-color 180ms cubic-bezier(0.4, 0, 0.2, 1)',
-    selectors: {
-      '&:focus-within': {
-        borderColor: themeVars.color.blue500,
-      },
-    },
-  },
-  variants: {
-    isDragOver: {
-      true: {
-        borderStyle: 'dashed',
-        borderColor: themeVars.color.grey400,
-      },
-      false: {},
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  backgroundColor: themeVars.color.white,
+  borderRadius: '12px',
+  padding: '1.6rem 1.8rem',
+  border: `1px solid ${themeVars.color.grey300}`,
+  transition: 'border-color 180ms cubic-bezier(0.4, 0, 0.2, 1)',
+  selectors: {
+    '&:focus-within': {
+      borderColor: themeVars.color.blue500,
     },
   },
 });

--- a/apps/client/src/features/ai-panel/components/prompt-input/prompt-input.tsx
+++ b/apps/client/src/features/ai-panel/components/prompt-input/prompt-input.tsx
@@ -20,7 +20,6 @@ interface PromptInputProps {
   disabled?: boolean;
   selectedMemos?: SelectedMemoType[];
   onRemoveMemo: (memoId: number) => void;
-  isDragOver: boolean;
 }
 
 const PromptInput = ({
@@ -31,7 +30,6 @@ const PromptInput = ({
   disabled = false,
   selectedMemos = [],
   onRemoveMemo,
-  isDragOver,
 }: PromptInputProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -60,7 +58,7 @@ const PromptInput = ({
   };
 
   return (
-    <div className={styles.container({ isDragOver })}>
+    <div className={styles.container}>
       {selectedMemos.length > 0 && (
         <div className={styles.memoList}>
           {selectedMemos.map(({ memoId, title }) => (

--- a/apps/client/src/pages/memos/components/memo-card-list/memo-card-list.tsx
+++ b/apps/client/src/pages/memos/components/memo-card-list/memo-card-list.tsx
@@ -63,8 +63,7 @@ const MemoCardList = ({
       preview.style.width = `${rect.width}px`;
       preview.style.height = `${rect.height}px`;
       preview.style.pointerEvents = 'none';
-      // 복제 시점엔 아직 isDragging 리렌더가 반영되지 않으므로, 클래스를
-      // 드래그 상태 스타일로 직접 교체해 고스트가 드래그 중 모습으로 보이게 한다.
+      preview.setAttribute('aria-hidden', 'true');
       preview.className = cardContainer({
         isSelected: selectedMemoIds.includes(memo.memoId),
         isDragging: true,

--- a/apps/client/src/pages/memos/components/memo-card-list/memo-card-list.tsx
+++ b/apps/client/src/pages/memos/components/memo-card-list/memo-card-list.tsx
@@ -1,10 +1,15 @@
+import { DragEvent, useState } from 'react';
+import { SelectedMemoType } from '@features/ai-panel/types/ai-panel.types';
+
 import MemoCard, {
   MemoCardInfoType,
 } from '@pages/memos/components/memo-card/memo-card';
 
+import { MEMO_DRAG_DATA_FORMAT } from '@shared/constants/memo-drag-data';
 import { components } from '@shared/types/schema';
 
 import * as styles from './memo-card-list.css';
+import { cardContainer } from '@pages/memos/components/memo-card/memo-card.css';
 
 type MemoCardResponse = components['schemas']['MemoDashboardResponse'];
 
@@ -21,17 +26,72 @@ const CardInfo = (memo: MemoCardResponse): MemoCardInfoType => ({
 
 interface MemoCardListProps {
   cards: MemoCardResponse[];
-  isSelected: boolean;
-  isDragging: boolean;
+  selectedMemoIds?: number[];
+  isDraggable?: boolean;
   onClickCard: () => void;
+  onDraggingChange?: (isDragging: boolean) => void;
 }
 
 const MemoCardList = ({
   cards,
-  isSelected,
-  isDragging,
+  selectedMemoIds = [],
+  isDraggable = false,
   onClickCard,
+  onDraggingChange,
 }: MemoCardListProps) => {
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+
+  const handleDragStart =
+    (memo: MemoCardResponse) => (event: DragEvent<HTMLElement>) => {
+      const dragData: SelectedMemoType = {
+        memoId: memo.memoId,
+        title: memo.title,
+      };
+      event.dataTransfer.setData(
+        MEMO_DRAG_DATA_FORMAT,
+        JSON.stringify(dragData),
+      );
+      event.dataTransfer.effectAllowed = 'copy';
+
+      const cardElement = event.currentTarget;
+      const mountTarget = cardElement.parentElement ?? document.body;
+      const rect = cardElement.getBoundingClientRect();
+      const preview = cardElement.cloneNode(true) as HTMLElement;
+      preview.style.position = 'fixed';
+      preview.style.top = '-9999px';
+      preview.style.left = '-9999px';
+      preview.style.width = `${rect.width}px`;
+      preview.style.height = `${rect.height}px`;
+      preview.style.pointerEvents = 'none';
+      // 복제 시점엔 아직 isDragging 리렌더가 반영되지 않으므로, 클래스를
+      // 드래그 상태 스타일로 직접 교체해 고스트가 드래그 중 모습으로 보이게 한다.
+      preview.className = cardContainer({
+        isSelected: selectedMemoIds.includes(memo.memoId),
+        isDragging: true,
+        isNew: memo.isNew,
+      });
+      mountTarget.appendChild(preview);
+
+      event.dataTransfer.setDragImage(
+        preview,
+        event.clientX - rect.left,
+        event.clientY - rect.top,
+      );
+
+      setTimeout(() => {
+        if (preview.parentNode === mountTarget)
+          mountTarget.removeChild(preview);
+      }, 0);
+
+      setDraggingId(memo.memoId);
+      onDraggingChange?.(true);
+    };
+
+  const handleDragEnd = () => {
+    setDraggingId(null);
+    onDraggingChange?.(false);
+  };
+
   return (
     <div className={styles.memoListContainer}>
       <div className={styles.memoListGrid}>
@@ -39,8 +99,11 @@ const MemoCardList = ({
           <MemoCard
             key={card.memoId}
             {...CardInfo(card)}
-            isSelected={isSelected}
-            isDragging={isDragging}
+            isSelected={selectedMemoIds.includes(card.memoId)}
+            isDragging={draggingId === card.memoId}
+            draggable={isDraggable}
+            onDragStart={handleDragStart(card)}
+            onDragEnd={handleDragEnd}
             onClick={onClickCard}
           />
         ))}

--- a/apps/client/src/pages/memos/components/memo-card/memo-card.css.ts
+++ b/apps/client/src/pages/memos/components/memo-card/memo-card.css.ts
@@ -25,24 +25,25 @@ const baseStyle = {
 } as const;
 
 const selectedStyle = {
-  border: `1px solid ${themeVars.color.grey400}`,
+  border: `1.5px solid ${themeVars.color.grey400}`,
   backgroundColor: themeVars.color.grey100,
 } as const;
 
 const draggingStyle = {
+  border: `1.5px solid ${themeVars.color.blue400}`,
   backgroundColor: themeVars.color.blue50,
   cursor: 'grabbing',
+  selectors: {
+    '&:hover': {
+      border: `1.5px solid ${themeVars.color.blue400}`,
+      backgroundColor: themeVars.color.blue50,
+    },
+  },
 } as const;
 
 const isNewSelectedStyle = {
   border: `1px solid ${themeVars.color.grey400}`,
   background: themeVars.color.grey100,
-  selectors: {
-    '&:hover': {
-      border: `1px solid ${themeVars.color.grey400}`,
-      background: themeVars.color.grey100,
-    },
-  },
 } as const;
 
 const isNewStyle = {

--- a/apps/client/src/pages/memos/components/memo-card/memo-card.tsx
+++ b/apps/client/src/pages/memos/components/memo-card/memo-card.tsx
@@ -44,7 +44,6 @@ const MemoCard = ({
     <article
       {...props}
       className={styles.cardContainer({ isSelected, isDragging, isNew })}
-      draggable
     >
       <div className={styles.mainInfoContainer}>
         <div className={styles.tagContainer}>

--- a/apps/client/src/pages/memos/memos-page.tsx
+++ b/apps/client/src/pages/memos/memos-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useAiPanel } from '@features/ai-panel';
 import FilterModal from '@features/filter-modal/filter-modal';
 import { PATH } from '@router/path';
 import { useNavigate, useSearchParams } from 'react-router';
@@ -21,6 +22,7 @@ const AllMemoPage = () => {
   const selectedTagIds = searchParams.getAll('tag').map(Number);
   const activeTagIds = selectedTagIds.length ? selectedTagIds : undefined;
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const { isOpen: isAiPanelOpen, selectedMemos } = useAiPanel();
 
   const { data: flatTags = [] } = useFlatTags();
   const tagsById = new Map(flatTags.map((tag) => [tag.tagId, tag]));
@@ -91,12 +93,11 @@ const AllMemoPage = () => {
         />
       ) : (
         <>
-          {/* 카드 선택/드래그, 상세 페이지 연결 전까지 임시 값 전달 */}
           <MemoCardList
             cards={memosList ?? []}
-            isSelected={false}
-            isDragging={false}
-            onClickCard={() => {}}
+            selectedMemoIds={selectedMemos.map((memo) => memo.memoId)}
+            isDraggable={isAiPanelOpen}
+            onClickCard={() => {}} // TODO: 상세 페이지 연결
           />
           <div ref={loadMoreRef} />
         </>

--- a/apps/client/src/shared/constants/memo-drag-data.ts
+++ b/apps/client/src/shared/constants/memo-drag-data.ts
@@ -1,0 +1,1 @@
+export const MEMO_DRAG_DATA_FORMAT = 'application/x-clustar-memo';

--- a/packages/cds-token/src/color.ts
+++ b/packages/cds-token/src/color.ts
@@ -81,4 +81,5 @@ export const color = {
 
   // Opacity Colors
   opacity35: 'var(--opaticy35, rgba(60, 60, 60, 0.35))',
+  opacity90: 'rgba(239, 239, 243, 0.9)',
 } as const;

--- a/packages/cds-token/src/z-index.ts
+++ b/packages/cds-token/src/z-index.ts
@@ -2,6 +2,7 @@ export const zIndex = {
   deep: '-2',
   back: '-1',
   default: '0',
+  panelOverlay: '50',
   sidebar: '100',
   button: '200',
   modalOverlay: '300',


### PR DESCRIPTION
## 📌 Summary

> - #315

메모 카드를 드래그해서 AI 패널로 끌어다 놓으면 선택 메모로 추가되는 드래그 앤 드롭을 구현했습니다.

## 📚 Tasks

- 메모 카드 드래그 시작 및 고스트 이미지 구현
- AI 패널에 메모 드롭 존 연결

## 🔍 Describe

### 카드 컴포넌트에서 드래그 속성 제거 → 리스트 컴포넌트로 이동
- 기존에는 `memo-card.tsx`에 `draggable`이 하드코딩돼 있어서 AI 패널이 열려 있지 않은 상태에서도 카드를 드래그할 수 있었습니다. 카드가 아무 상황이 아닌데 드래그가 되는 동작이 어색하다고 생각해서 `draggable` 속성을 `MemoCard`에서 제거하고 상위 `MemoCardList`가 `isDraggable` prop(=`isAIOpen`)으로 각 카드의 드래그 가능 여부를 제어하도록 옮겼습니다. 드래그는 **AI 패널이 열려 있을 때만 의미 있는 동작**이기 때문에 그 조건을 아는 상위 컴포넌트가 소유하는 게 자연스럽다고 생각했습니다.

- 카드 하나하나가 "내가 지금 드래그 중인지"를 스스로 판단하려면 형제 카드들과 상태를 공유해야 하는데 그러면 카드가 리스트의 존재를 알아야 해서 리스트가 각 카드에 `isDragging`을 내려주는 편이 의존 방향이 깔끔한 것 같아같은 이유로 드래그 시작/종료 핸들러(`onDragStart`, `onDragEnd`)도 `MemoCardList`가 소유하게 되었고 드래그 중인 카드 id(`draggingId`)도 리스트 레벨에서 관리하도록 했습니다.

### 메모 카드 드래그 시작 및 고스트 이미지 구현
- `memo-card-list.tsx`에 `handleDragStart` / `handleDragEnd`를 구현해 드래그 시작 시 `MEMO_DRAG_DATA_FORMAT`(`application/x-clustar-memo`)이라는 커스텀 dataTransfer 타입으로 `SelectedMemoType` payload를 담아 전달합니다.

- setDragImage로 커스텀 고스트 이미지를 지정하기 전에는 브라우저가 dragstart 시점의 카드 엘리먼트를 화면에 렌더링된 그대로 캡처해서 기본 드래그 이미지로 사용합니다. 이때 AI 패널이 카드 일부 위에 겹쳐 있는 상태이면 브라우저가 만드는 스냅샷도 그 가려진 화면을 그대로 캡처해서 드래그 중인 카드가 잘린 것처럼 보였습니다. 카드를 화면 밖에 복제해 setDragImage로 명시적으로 넘겨주면 AI 패널에 가려진 실제 렌더링 상태와 무관하게 항상 온전한 카드 모양을 고스트 이미지로 쓸 수 있어 이 문제를 해결했습니다.

https://github.com/user-attachments/assets/86b41ad4-951e-40cf-b1cd-752e054a1f60



### AI 패널에 메모 드롭 존 연결
- `ai-panel.tsx`에 `onDragEnter` / `onDragOver` / `onDragLeave` / `onDrop` 핸들러를 추가해 카드 리스트와 같은 `MEMO_DRAG_DATA_FORMAT` payload 계약을 공유하도록 했습니다. 
- `dragenter` / `dragleave`는 자식 요소를 넘나들 때마다 반복 발생하는 이벤트라 단순히 `dragleave`에서 바로 오버레이를 끄면 패널 내부의 자식 요소 경계를 넘을 때마다 깜빡이게 됩니다. 이를 막기 위해 깊이 카운터(`dragDepthRef`)로 enter/leave 횟수를 세어, 카운터가 0이 될 때(=패널 바깥 경계를 완전히 벗어났을 때)만 드롭 오버레이(`MemoDropOverlay`)를 끄도록 처리했습니다.



## 👀 To Reviewer

## 📸 Screenshot

https://github.com/user-attachments/assets/b89c766f-98b4-4a57-ba74-3be5a35d337f
