### PR TITLE
Feat(client): memo-detail 뷰에 markdown-editor 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 
 # .lefthook
 .lefthook
+
+# ai-agent
+AGENTS.md

--- a/apps/client/src/shared/components/memo-detail/memo-detail.tsx
+++ b/apps/client/src/shared/components/memo-detail/memo-detail.tsx
@@ -4,6 +4,7 @@ import TagInputField from '@features/tag-popover/tag-input-field/tag-input-field
 import { Icon } from '@cds/icon';
 import { Tooltip } from '@cds/ui';
 
+import { MarkdownEditor } from '@shared/markdown-editor';
 import { formatFullDate } from '@shared/utils/format-date';
 
 import DeleteMemoModal from './components/delete-memo-modal/delete-memo-modal';
@@ -113,19 +114,20 @@ const MemoDetail = ({ memoId: selectedMemoId, onDeleted }: MemoDetailProps) => {
                 }
               />
             </div>
-
-            <textarea
-              className={styles.content}
+            <MarkdownEditor
               value={content}
-              placeholder="내용을 입력해주세요."
-              aria-label="메모 내용"
-              onChange={(event) =>
+              onChange={(markdown) =>
                 setMemo((previousMemo) => ({
                   ...previousMemo,
-                  content: event.target.value,
+                  content: markdown,
                 }))
               }
-            />
+            >
+              <MarkdownEditor.Input
+                className={styles.content}
+                placeholder="내용을 입력해주세요."
+              />
+            </MarkdownEditor>
           </div>
 
           {files.length > 0 && (

--- a/apps/client/src/shared/markdown-editor/markdown-editor.css.ts
+++ b/apps/client/src/shared/markdown-editor/markdown-editor.css.ts
@@ -24,7 +24,16 @@ const marker = {
 } as const;
 
 export const container = style({
+  position: 'relative',
   counterReset: ORDERED_COUNTER,
+  selectors: {
+    '&[data-empty="true"]::before': {
+      content: 'attr(data-placeholder)',
+      position: 'absolute',
+      color: themeVars.color.grey400,
+      pointerEvents: 'none',
+    },
+  },
 });
 
 export const paragraph = block;

--- a/apps/client/src/shared/markdown-editor/markdown-editor.test.tsx
+++ b/apps/client/src/shared/markdown-editor/markdown-editor.test.tsx
@@ -16,7 +16,7 @@ const renderEditor = (initialValue: string) => {
 
     return (
       <MarkdownEditor value={value} onChange={setValue}>
-        <MarkdownEditor.Input />
+        <MarkdownEditor.Input placeholder="내용을 입력해주세요." />
       </MarkdownEditor>
     );
   };


### PR DESCRIPTION
## 📌 Summary

> - #344 

memo-detail 뷰에 markdown-editor 적용

## 📚 Tasks

- 마크다운 적용 시키기
- placeholder 보이게 수정하기

## 🔍 Describe

- 마크다운 적용했습니다 !!

### placeholder가 안 보이던 문제

`MarkdownEditor.Input`은 `textarea`가 아니라 `contentEditable` div예요. 네이티브 `placeholder` 속성은 `input`/`textarea`/`select` 전용이라 여기서는 아무 일도 하지 않아요.

`Input`이 `data-placeholder`를 붙이고, `markEmptiness`가 내용이 비면 `data-empty="true"`를 붙이고 있었는데, 정작 이 두 속성을 읽어서 화면에 그려주는 CSS 규칙이 없었어요. 그래서 prop을 넘겨도 아무것도 보이지 않았어요.

일단 CSS로 그려주는 방식으로 해결했어요. `container`에 아래 규칙을 추가했어요.

```ts
'&[data-empty="true"]::before': {
  content: 'attr(data-placeholder)',
  position: 'absolute',
  color: themeVars.color.grey400,
  pointerEvents: 'none',
}
```

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

## 📸 Screenshot


https://github.com/user-attachments/assets/52df248f-1682-49d3-aefc-7bb96b271af6


