### PR TITLE
Fix(client, cds-token): use-media-query 구현, ai-panel이 열릴 때의 따른 sidebar 열고닫힘 유무 수정

### DIFF
--- a/apps/client/src/features/ai-panel/ai-panel.css.ts
+++ b/apps/client/src/features/ai-panel/ai-panel.css.ts
@@ -6,7 +6,7 @@ export const container = style({
   position: 'fixed',
   top: 0,
   right: 0,
-  zIndex: themeVars.zIndex.modalContent,
+  zIndex: themeVars.zIndex.aiPanel,
   display: 'flex',
   flexDirection: 'column',
   width: '48rem',

--- a/apps/client/src/features/ai-panel/components/ai-panel-header/ai-panel-header.css.ts
+++ b/apps/client/src/features/ai-panel/components/ai-panel-header/ai-panel-header.css.ts
@@ -52,7 +52,7 @@ export const tooltip = recipe({
   base: {
     position: 'absolute',
     top: 'calc(100% + 0.4rem)',
-    zIndex: themeVars.zIndex.modalContent,
+    zIndex: themeVars.zIndex.aiPanel,
     opacity: 0,
     pointerEvents: 'none',
     transition: 'opacity 120ms ease',

--- a/apps/client/src/features/ai-panel/components/chat/ai-answer/ai-answer.css.ts
+++ b/apps/client/src/features/ai-panel/components/chat/ai-answer/ai-answer.css.ts
@@ -52,7 +52,7 @@ export const tooltip = recipe({
   base: {
     position: 'absolute',
     top: 'calc(100% + 0.4rem)',
-    zIndex: themeVars.zIndex.modalContent,
+    zIndex: themeVars.zIndex.aiPanel,
     opacity: 0,
     pointerEvents: 'none',
     transition: 'opacity 120ms ease',

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar-menu-section/sidebar-menu-section.tsx
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar-menu-section/sidebar-menu-section.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import MemoSearchModal from '@features/memo-search-modal/memo-search-modal';
 import { PATH } from '@router/path';
 
@@ -14,7 +13,10 @@ import * as styles from '../sidebar.css';
 interface SidebarMenuSectionProps {
   selection: SidebarSelection;
   onSelectMenu: (path: string) => void;
+  onClickSearch: () => void;
   onExpand: () => void;
+  isSearchMoalOpen: boolean;
+  setIsSearchModalOpen: (value: boolean) => void;
 }
 
 interface MenuEntry {
@@ -42,30 +44,22 @@ const MENU_ITEMS: MenuEntry[] = [
 const SidebarMenuSection = ({
   selection,
   onSelectMenu,
-  onExpand,
+  onClickSearch,
+  isSearchMoalOpen,
+  setIsSearchModalOpen,
 }: SidebarMenuSectionProps) => {
-  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const selectedMenuPath = selection.type === 'menu' ? selection.path : null;
-
-  const handleClickSearch = () => {
-    onExpand();
-    setIsSearchModalOpen(true);
-  };
 
   return (
     <ul className={styles.pannelList}>
       <li key="search" className={styles.pannelItem}>
-        <MenuItem
-          iconName="ic_search"
-          content="검색"
-          onClick={handleClickSearch}
-        />
+        <MenuItem iconName="ic_search" content="검색" onClick={onClickSearch} />
         <div className={styles.tooltip}>
           <Tooltip title="검색" />
         </div>
       </li>
       <MemoSearchModal
-        open={isSearchModalOpen}
+        open={isSearchMoalOpen}
         onOpenChange={setIsSearchModalOpen}
       />
       {MENU_ITEMS.map(({ id, iconName, text, path }) => (

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.tsx
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { useAiPanel } from '@features/ai-panel';
 import { PATH } from '@router/path';
 import { useLocation, useNavigate, useSearchParams } from 'react-router';
 
@@ -5,6 +7,8 @@ import { Icon } from '@cds/icon';
 import { Tooltip } from '@cds/ui';
 
 import MenuItem from '@shared/components/menu-item/menu-item';
+import { DESKTOP_MEDIA_QUERY } from '@shared/constants/media-query';
+import { useMediaQuery } from '@shared/hooks/use-media-query';
 
 import { useSidebar } from './sidebar-context';
 import SidebarMenuSection from './sidebar-menu-section/sidebar-menu-section';
@@ -15,11 +19,17 @@ import * as styles from './sidebar.css';
 
 const Sidebar = () => {
   const { isExpanded, toggleSidebar, expand } = useSidebar();
+  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
+  const { isOpen } = useAiPanel();
+  const isNarrowLayout = useMediaQuery(`(max-width: ${DESKTOP_MEDIA_QUERY})`);
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
   const tagParam = searchParams.get('tag');
+
+  const isSidebarCollapse = isNarrowLayout && isOpen;
+  const isSidebarExpanded = isExpanded && !isSidebarCollapse;
 
   // 태그 선택은 `/memos?tag=`로 이동해 pathname이 모든 메모와 같아지므로,
   // 태그가 경로보다 우선한다는 규칙을 여기 한 곳에서만 정한다.
@@ -33,18 +43,23 @@ const Sidebar = () => {
     expand();
   };
 
+  const handleSelectSearch = () => {
+    expand();
+    setIsSearchModalOpen(true);
+  };
+
   const handleSelectTag = (tagId: number) => {
     navigate(`${PATH.MEMOS}?tag=${tagId}`);
   };
 
   return (
-    <nav className={styles.sidebar} data-expanded={isExpanded}>
+    <nav className={styles.sidebar} data-expanded={isSidebarExpanded}>
       {/* header */}
       <header className={styles.header}>
         <button
           className={styles.logoButton}
           onClick={toggleSidebar}
-          disabled={isExpanded}
+          disabled={isSidebarCollapse}
           aria-label="사이드바 토글"
         >
           <Icon name="ic_logo_symbol" size={32} className={styles.logoSymbol} />
@@ -71,6 +86,9 @@ const Sidebar = () => {
           selection={selection}
           onSelectMenu={handleSelectMenu}
           onExpand={expand}
+          onClickSearch={handleSelectSearch}
+          setIsSearchModalOpen={setIsSearchModalOpen}
+          isSearchMoalOpen={isSearchModalOpen}
         />
       </section>
 
@@ -79,7 +97,7 @@ const Sidebar = () => {
         <span className={styles.sectionTitle}>태그</span>
         <hr className={styles.collapsedDivider} />
         <SidebarTagSection
-          isExpanded={isExpanded}
+          isExpanded={isSidebarExpanded}
           selection={selection}
           onSelectTag={handleSelectTag}
           onExpand={expand}

--- a/apps/client/src/shared/constants/media-query.ts
+++ b/apps/client/src/shared/constants/media-query.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_MEDIA_QUERY = '1620px';

--- a/apps/client/src/shared/hooks/use-media-query.ts
+++ b/apps/client/src/shared/hooks/use-media-query.ts
@@ -1,0 +1,14 @@
+import { useSyncExternalStore } from 'react';
+
+export const useMediaQuery = (query: string) =>
+  useSyncExternalStore(
+    (onMediaQueryChange) => {
+      const mediaQueryList = window.matchMedia(query);
+
+      mediaQueryList.addEventListener('change', onMediaQueryChange);
+
+      return () =>
+        mediaQueryList.removeEventListener('change', onMediaQueryChange);
+    },
+    () => window.matchMedia(query).matches,
+  );

--- a/packages/cds-token/src/z-index.ts
+++ b/packages/cds-token/src/z-index.ts
@@ -4,6 +4,7 @@ export const zIndex = {
   default: '0',
   panelOverlay: '50',
   sidebar: '100',
+  aiPanel: '100',
   button: '200',
   modalOverlay: '300',
   modalContent: '400',


### PR DESCRIPTION
## 📌 Summary

> - #355 

ai-panel이 열릴 때의 따른 sidebar 열고닫힘 유무 수정을 진행했어요.

## 📚 Tasks

- use-media-query 구현
- ai-panel이 열릴 때의 따른 sidebar 열고닫힘 유무 수정

## 🔍 Describe

### 요구사항

디자인측에서 원하는 로직은 아래와 같아요

<img width="646" height="275" alt="image" src="https://github.com/user-attachments/assets/ba3a5dba-3d49-4cbf-9318-232b525ea704" />

1620px보다 작을 때에는 ai-panel이 열릴 때 자동으로 sidebar가 닫히길 바랬고,
1620px보다 클 때에는 자유롭길 원했어요.

sidebar와 ai-panel 둘 다 열리면 가운데에 있는 card의 정보를 조금밖에 볼 수 없어서 요구된 사항이였어요.

### 구현 설명

### 1. 사이드바 접힘 조건을 파생값으로 계산

  해상도 `1620px` 미만에서 AI 패널이 열리면 사이드바를 접고, 그 동안에는 펼쳐지지 않도록 했어요.

  ```tsx
  const isSidebarCollapse = isNarrowLayout && isOpen;
  const isSidebarExpanded = isExpanded && !isSidebarCollapse;
  ```

  **`useEffect`로 `collapse()`를 호출하지 않은 이유**

  - 렌더 중에 계산하므로 조건이 성립하는 즉시 접혀요. effect는 커밋 이후에 실행돼서 한 프레임 펼쳐진 상태가 그려질 수 있어요.
  - `useSidebar`의 `isExpanded`(사용자가 직접 고른 값)를 덮어쓰지 않아서 패널을 닫거나 창을 넓히면 사용자가 마지막에 선택한 상태로 그대로 복귀하도록 했어요. 

  **`isSidebarExpanded`를 넘기는 곳이 두 군데인 이유**

  `data-expanded`와 `SidebarTagSection`의 `isExpanded`에 모두 전달해야 모두 닫힌 상태가 돼요. 
태그 섹션은 스타일이 아니라 조건부 렌더라서 CSS 미디어 쿼리만으로는 트리가 마운트된 채 8rem 안에 남습니다. 접힘 시 트리를 렌더하지 않는 기존 의도도 유지돼야 해서 JS 값으로 처리했어요

### 2. `useMediaQuery` 훅 추가

  ```tsx
  const isNarrowLayout = useMediaQuery(`(max-width: ${DESKTOP_MEDIA_QUERY})`);
  ```

  `matchMedia`는 React 밖에 이미 상태를 가진 스토어라, useState로 복사하지 않고 useSyncExternalStore로 구독하는 구조로 가져갔어요. 복사본을 두면 마운트~effect 사이의 변화를 따라잡는 코드가 따로 필요해지는데 그 원인을 없앴습니당구리

  브레이크포인트 값은 `shared/constants/media-query.ts`의 `DESKTOP_MEDIA_QUERY`로 분리해 다른 화면에서도 같은 기준을 쓰도록 했어용

### 3. z-index 토큰 분리

  AI 패널이 `modalContent` 토큰을 빌려 쓰고 있어서 `aiPanel`토큰을 추가하고 패널, 헤더, 답변에 적용했어요. 사이드바와 같은 위치로 맞춰 모달보다 아래에 놓이게 했습니당


## 📸 Screenshot

https://github.com/user-attachments/assets/d9cd3acd-a60d-46b6-ba04-4ff79c7f775e
