### PR TITLE
Feat(client): 사이드바 펼침 상태 유지 구현

### DIFF
--- a/apps/client/src/shared/components/layouts/sidebar/sidebar-context.tsx
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar-context.tsx
@@ -4,19 +4,27 @@ interface SidebarContextValue {
   isExpanded: boolean;
   toggleSidebar: () => void;
   expand: () => void;
-  collapse: () => void;
 }
+
+const SIDEBAR_EXPANDED_KEY = 'sidebarExpanded';
+
+const getStoredIsExpanded = () =>
+  localStorage.getItem(SIDEBAR_EXPANDED_KEY) !== 'false';
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 
 export const SidebarProvider = ({ children }: { children: ReactNode }) => {
-  const [isExpanded, setExpanded] = useState(true);
+  const [isExpanded, setExpanded] = useState(getStoredIsExpanded);
+
+  const updateExpanded = (nextIsExpanded: boolean) => {
+    localStorage.setItem(SIDEBAR_EXPANDED_KEY, String(nextIsExpanded));
+    setExpanded(nextIsExpanded);
+  };
 
   const value = {
     isExpanded,
-    toggleSidebar: () => setExpanded((prev) => !prev),
-    expand: () => setExpanded(true),
-    collapse: () => setExpanded(false),
+    toggleSidebar: () => updateExpanded(!isExpanded),
+    expand: () => updateExpanded(true),
   };
 
   return (

--- a/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
+++ b/apps/client/src/shared/components/layouts/sidebar/sidebar.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 import { zIndex } from '@cds/token';
-import { slideInLeft, themeVars } from '@cds/ui';
+import { themeVars } from '@cds/ui';
 
 export const sidebar = style({
   position: 'sticky',
@@ -13,7 +13,6 @@ export const sidebar = style({
   padding: '2rem',
   height: '100vh',
   flexShrink: '0',
-  animation: `${slideInLeft} 0.3s cubic-bezier(0.4, 0, 0.2, 1)`,
   transition: 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
   selectors: {
     '&[data-expanded="true"]': { width: '26rem' },


### PR DESCRIPTION
## 📌 Summary

> - #358 

사이드바 펼침 상태 유지를 구현했어요

## 📚 Tasks

- _해당 PR에 수행한 작업을 작성해주세요._

## 🔍 Describe

### 사이드바 펼침 상태를 localStorage에 저장

새로고침해도 사용자가 마지막에 고른 펼침/접힘 상태가 유지되도록 했어요.

`useState`의 lazy initializer

```tsx
const [isExpanded, setExpanded] = useState(getStoredIsExpanded);
```
함수를 그대로 넘겨 첫 렌더에서 한 번만 읽게 했어요.

### 저장

```tsx
const updateExpanded = (nextIsExpanded: boolean) => {
  localStorage.setItem(SIDEBAR_EXPANDED_KEY, String(nextIsExpanded));
  setExpanded(nextIsExpanded);
};
```

저장은 사용자 이벤트에 대한 반응이라 핸들러에서 처리하도록 했어요

기본값은 `localStorage.getItem(...) !== 'false'` 한 줄로 처리했어요. 
저장된 값이 없는 첫 진입 시에는 펼침을 기본 값으로 했어요


## 📸 Screenshot

https://github.com/user-attachments/assets/1c8a526b-194b-43b7-b55d-8a2da460d809

